### PR TITLE
Add a sensu_check resource, closes #10

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -52,6 +52,7 @@ module SensuCookbook
       a['organization'] = new_resource.organization if new_resource.organization
       a['sha512'] = new_resource.sha512
       a['url'] = new_resource.url
+      a
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,48 @@
+module SensuCookbook
+  module Helpers
+    # Extract object type from resource type
+    def type_from_name
+      new_resource.declared_type.to_s.split('_').last
+    end
+
+    # Pluralize object directory name
+    def object_dir
+      ::File.join(new_resource.config_home, type_from_name) + 's'
+    end
+
+    def object_file
+      ::File.join(object_dir, new_resource.name) + '.json'
+    end
+
+    # Get check properties from the resource
+    # https://docs.sensu.io/sensu-core/2.0/reference/checks/#check-attributes
+    def check_from_resource
+      spec = {}
+      spec['check_hooks'] = new_resource.check_hooks if new_resource.check_hooks
+      spec['command'] = new_resource.command
+      spec['cron'] = new_resource.cron
+      spec['environment'] = new_resource.environment
+      spec['handlers'] = new_resource.handlers
+      spec['high_flap_threshold'] = new_resource.high_flap_threshold if new_resource.high_flap_threshold
+      spec['interval'] = new_resource.interval if new_resource.interval
+      spec['low_flap_threshold'] = new_resource.low_flap_threshold if new_resource.low_flap_threshold
+      spec['name'] = new_resource.name
+      spec['organization'] = new_resource.organization
+      spec['proxy_entity_id'] = new_resource.proxy_entity_id if new_resource.proxy_entity_id
+      spec['proxy_requests'] = new_resource.proxy_requests if new_resource.proxy_requests
+      spec['publish'] = new_resource.publish if new_resource.publish
+      spec['round_robin'] = new_resource.round_robin if new_resource.round_robin
+      spec['runtime_assets'] = new_resource.runtime_assets if new_resource.runtime_assets
+      spec['stdin'] = new_resource.stdin
+      spec['subdue'] = new_resource.subdue if new_resource.subdue
+      spec['subscriptions'] = new_resource.subscriptions
+      spec['timeout'] = new_resource.timeout if new_resource.timeout
+      spec['ttl'] = new_resource.ttl if new_resource.ttl
+
+      c = {}
+      c['type'] = type_from_name.capitalize
+      c['spec'] = spec
+      c
+    end
+  end
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,6 +22,7 @@ module SensuCookbook
       spec['command'] = new_resource.command
       spec['cron'] = new_resource.cron
       spec['environment'] = new_resource.environment
+      spec['extended_attributes'] = new_resource.extended_attributes if new_resource.extended_attributes
       spec['handlers'] = new_resource.handlers
       spec['high_flap_threshold'] = new_resource.high_flap_threshold if new_resource.high_flap_threshold
       spec['interval'] = new_resource.interval if new_resource.interval

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,5 +44,14 @@ module SensuCookbook
       c['spec'] = spec
       c
     end
+
+    def asset_from_resource
+      a = {}
+      a['name'] = new_resource.name
+      a['metadata'] = new_resource.metadata if new_resource.metadata
+      a['organization'] = new_resource.organization if new_resource.organization
+      a['sha512'] = new_resource.sha512
+      a['url'] = new_resource.url
+    end
   end
 end

--- a/libraries/helpers_sensuctl.rb
+++ b/libraries/helpers_sensuctl.rb
@@ -17,6 +17,16 @@ module SensuCookbook
       def sensuctl_configure_cmd
         [sensuctl_bin, 'configure', sensuctl_configure_opts].join(' ').strip
       end
+
+      def sensuctl_asset_update_opts
+        opts = []
+        opts << "--organization #{new_resource.organization}" if new_resource.organization
+        opts << "--environment #{new_resource.environment}" if new_resource.environment
+      end
+
+      def sensuctl_asset_update_cmd
+        [sensuctl_bin, 'asset', 'update', new_resource.name, sensuctl_asset_update_opts].join(' ').strip
+      end
     end
   end
 end

--- a/resources/asset.rb
+++ b/resources/asset.rb
@@ -1,0 +1,66 @@
+#
+# Cookbook Name:: sensu-go
+# Resource:: asset
+#
+# Copyright:: 2018 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+resource_name :sensu_asset
+
+property :config_home, String, default: '/etc/sensu'
+
+property :filters, Array
+property :metadata, Hash
+property :organization, String, default: 'default'
+property :sha512, String, required: true
+property :url, String, required: true
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+action :create do
+  directory object_dir do
+    action :create
+    recursive true
+  end
+
+  file object_file do
+    content JSON.generate(asset_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file}]"
+  end
+
+  execute "sensuctl create -f #{object_file}" do
+    action :nothing
+  end
+end
+
+action :update do
+  file object_file do
+    action :delete
+    notifies :run, "execute[sensuctl asset update #{new_resource.name}]"
+  end
+
+  execute "sensuctl asset update #{new_resource.name}" do
+    command sensuctl_asset_update_cmd
+    action :nothing
+  end
+end

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -29,9 +29,9 @@ property :config_home, String, default: '/etc/sensu'
 
 property :check_hooks, Array
 property :command, String, default: '/bin/true', required: true
-property :cron, String, default: '* * * * *'
+property :cron, String
 property :environment, String, default: 'default'
-property :handlers, Array, default: ['default'], required: true
+property :handlers, Array, default: [], required: true
 property :high_flap_threshold, Integer
 property :interval, Integer
 property :low_flap_threshold, Integer
@@ -43,7 +43,7 @@ property :round_robin, [true, false]
 property :runtime_assets, Array
 property :stdin, [true, false], default: false
 property :subdue, Hash
-property :subscriptions, Array, default: ['default'], required: true
+property :subscriptions, Array, default: [], required: true
 property :timeout, Integer
 property :ttl, Integer
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -31,6 +31,7 @@ property :check_hooks, Array
 property :command, String, default: '/bin/true', required: true
 property :cron, String
 property :environment, String, default: 'default'
+property :extended_attributes, Hash
 property :handlers, Array, default: [], required: true
 property :high_flap_threshold, Integer
 property :interval, Integer

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -1,0 +1,79 @@
+#
+# Cookbook Name:: sensu-go
+# Resource:: check
+#
+# Copyright:: 2018 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+resource_name :sensu_check
+
+property :config_home, String, default: '/etc/sensu'
+
+property :check_hooks, Array
+property :command, String, default: '/bin/true', required: true
+property :cron, String, default: '* * * * *'
+property :environment, String, default: 'default'
+property :handlers, Array, default: ['default'], required: true
+property :high_flap_threshold, Integer
+property :interval, Integer
+property :low_flap_threshold, Integer
+property :organization, String, default: 'default'
+property :proxy_entity_id, String, regex: [/^[\w\.\-]+$/]
+property :proxy_requests, Hash
+property :publish, [true, false]
+property :round_robin, [true, false]
+property :runtime_assets, Array
+property :stdin, [true, false], default: false
+property :subdue, Hash
+property :subscriptions, Array, default: ['default'], required: true
+property :timeout, Integer
+property :ttl, Integer
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+action :create do
+  directory object_dir do
+    action :create
+    recursive true
+  end
+
+  file object_file do
+    content JSON.generate(check_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file}]"
+  end
+
+  execute "sensuctl create -f #{object_file}" do
+    action :nothing
+  end
+end
+
+action :delete do
+  file object_file do
+    action :delete
+    notifies :run, "execute[sensuctl check delete #{new_resource.name} --skip-confirm]"
+  end
+
+  execute "sensuctl check delete #{new_resource.name} --skip-confirm" do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -9,6 +9,14 @@ end
 sensu_check 'cron' do
   command '/bin/true'
   cron '@hourly'
-  subscriptions ['dad_jokes']
+  subscriptions %w(dad_jokes production)
+  handlers %w(pagerduty email)
+  extended_attributes(runbook: 'https://www.xkcd.com/378/')
+  publish false
+  ttl 100
+  high_flap_threshold 60
+  low_flap_threshold 20
+  subdue(days: { all: [{ begin: '12:00 AM', end: '11:59 PM' },
+                       { begin: '11:00 PM', end: '1:00 AM' }] })
   action :create
 end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -5,3 +5,9 @@ sensu_agent 'default'
 sensu_ctl 'default' do
   action [:install, :configure]
 end
+
+sensu_check 'cron' do
+  command '/bin/true'
+  subscriptions ['dad_jokes']
+  action :create
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -8,6 +8,7 @@ end
 
 sensu_check 'cron' do
   command '/bin/true'
+  cron '@hourly'
   subscriptions ['dad_jokes']
   action :create
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -43,6 +43,17 @@ describe command('sensuctl user list') do
 end
 
 describe json('/etc/sensu/checks/cron.json') do
+  its(%w(type)) { should eq 'Check' }
   its(%w(spec name)) { should eq 'cron' }
+  its(%w(spec cron)) { should eq '@hourly' }
+  its(%w(spec environment)) { should eq 'default' }
   its(%w(spec subscriptions)) { should include 'dad_jokes' }
+  its(%w(spec subscriptions)) { should include 'production' }
+  its(%w(spec handlers)) { should include 'pagerduty' }
+  its(%w(spec handlers)) { should include 'email' }
+  its(%w(spec extended_attributes runbook)) { should eq 'https://www.xkcd.com/378/' }
+  its(['spec', 'subdue', 'days', 'all', 0, 'begin']) { should eq '12:00 AM' }
+  its(['spec', 'subdue', 'days', 'all', 0, 'end']) { should eq '11:59 PM' }
+  its(['spec', 'subdue', 'days', 'all', 1, 'begin']) { should eq '11:00 PM' }
+  its(['spec', 'subdue', 'days', 'all', 1, 'end']) { should eq '1:00 AM' }
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -41,3 +41,9 @@ describe command('sensuctl user list') do
   its('stdout') { should match /Username/ }
   its('exit_status') { should eq 0 }
 end
+
+describe command('sensuctl check list') do
+  its('stdout') { should match /cron/ }
+  its('stdout') { should match /dad_jokes/ }
+  its('exit_status') { should eq 0 }
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -42,8 +42,7 @@ describe command('sensuctl user list') do
   its('exit_status') { should eq 0 }
 end
 
-describe command('sensuctl check list') do
-  its('stdout') { should match /cron/ }
-  its('stdout') { should match /dad_jokes/ }
-  its('exit_status') { should eq 0 }
+describe json('/etc/sensu/checks/cron.json') do
+  its(%w(spec name)) { should eq 'cron' }
+  its(%w(spec subscriptions)) { should include 'dad_jokes' }
 end


### PR DESCRIPTION
This will generate the object files necessary for a single check definition and
executes `sensuctl create -f` with the generated file. Includes `:create` and `:delete` actions. 

Includes unit/integration tests.
