### PR TITLE
Add basic sensu_handler resource, closes #11

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -59,5 +59,25 @@ module SensuCookbook
       a['spec'] = spec
       a
     end
+
+    def handler_from_resource
+      spec = {}
+      spec['name'] = new_resource.name
+      spec['command'] = new_resource.command if new_resource.command
+      spec['env_vars'] = new_resource.env_vars if new_resource.env_vars
+      spec['environment'] = new_resource.environment
+      spec['filters'] = new_resource.filters if new_resource.filters
+      spec['handlers'] = new_resource.handlers if new_resource.handlers
+      spec['mutator'] = new_resource.mutator if new_resource.mutator
+      spec['organization'] = new_resource.organization
+      spec['socket'] = new_resource.socket if new_resource.socket
+      spec['timeout'] = new_resource.timeout if new_resource.timeout
+      spec['type'] = new_resource.type
+
+      h = {}
+      h['type'] = type_from_name
+      h['spec'] = spec
+      h
+    end
   end
 end

--- a/resources/handler.rb
+++ b/resources/handler.rb
@@ -1,0 +1,70 @@
+#
+# Cookbook Name:: sensu-go
+# Resource:: handler
+#
+# Copyright:: 2018 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+resource_name :sensu_handler
+
+property :config_home, String, default: '/etc/sensu'
+
+property :command, String # only allowed if type == pipe
+property :env_vars, Array
+property :environment, String, default: 'default'
+property :filters, Array
+property :handlers, Array
+property :mutator, String
+property :organization, String, default: 'default'
+property :socket, Hash # can only have host: string, port: int
+property :timeout, Integer
+property :type, String, equal_to: %w(pipe tcp udp set), required: true
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+action :create do
+  directory object_dir do
+    action :create
+    recursive true
+  end
+
+  file object_file do
+    content JSON.generate(handler_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file}]"
+  end
+
+  execute "sensuctl create -f #{object_file}" do
+    action :nothing
+  end
+end
+
+action :delete do
+  file object_file do
+    action :delete
+    notifies :run, "execute[sensuctl handler delete #{new_resource.name} --skip-confirm]"
+  end
+
+  execute "sensuctl handler delete #{new_resource.name} --skip-confirm" do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -29,3 +29,31 @@ assets.each do |name, property|
     sha512 property['checksum']
   end
 end
+
+sensu_handler 'slack' do
+  type 'pipe'
+  command 'handler-slack --webhook-url https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX --channel monitoring'
+end
+
+sensu_handler 'tcp_handler' do
+  type 'tcp'
+  socket(
+    host: '127.0.0.1',
+    port: 4444
+  )
+  timeout 30
+end
+
+sensu_handler 'udp_handler' do
+  type 'udp'
+  socket(
+    host: '127.0.0.1',
+    port: 4444
+  )
+  timeout 30
+end
+
+sensu_handler 'notify_the_world' do
+  type 'set'
+  handlers %w(slack tcp_handler udp_handler)
+end


### PR DESCRIPTION
Supports all types of handlers, no input validation provided.

Note that the implemented test usage is just pulled exactly from [sensu 2.0 docs.](https://docs.sensu.io/sensu-core/2.0/reference/handlers/#executing-multiple-handlers)