### PR TITLE
fix logic that allows specifying `'latest'` to ensure that version is always updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ### Fixed
 - moved `CODEOWNERS` into the correct location (@majormoses)
 - updated development dependencies (@majormoses)
+- using a version of `'latest'` for backend and agent providers will now upgrade to the test version
 
 [Unreleased]: https://github.com/sensu/sensu-go-chef/compare/37630d8624247f0e2dc41de8de8c2ccd29d55694...HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,9 @@ group :development do
   gem 'rb-readline' if Gem.win_platform?
   gem 'wdm', '>= 0.1.0' if Gem.win_platform?
   gem 'win32console' if Gem.win_platform?
+
+  # the following gems are needed if you use ssh-ed25519 keys
+  gem 'rbnacl', ['>= 3.2', '< 5.0'] unless ENV['TRAVIS']
+  gem 'rbnacl-libsodium' unless ENV['TRAVIS']
+  gem 'bcrypt_pbkdf', ['>= 1.0', '< 2.0'] unless ENV['TRAVIS']
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -109,5 +109,9 @@ module SensuCookbook
       m['spec'] = spec
       m
     end
+
+    def latest_version?(version)
+      version == 'latest' || version == :latest
+    end
   end
 end

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -43,8 +43,12 @@ action :install do
   end
 
   package 'sensu-agent' do
-    action :install
-    version new_resource.version unless new_resource.version == 'latest'
+    if new_resource.version == 'latest'
+      action :upgrade
+    else
+      version new_resource.version
+      action :install
+    end
   end
 
   # render template at /etc/sensu/agent.yml

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -25,6 +25,8 @@
 
 resource_name :sensu_agent
 
+include SensuCookbook::Helpers
+
 property :agent_id, String, name_property: true
 property :version, String, default: 'latest'
 property :repo, String, default: 'sensu/nightly'
@@ -43,7 +45,7 @@ action :install do
   end
 
   package 'sensu-agent' do
-    if new_resource.version == 'latest'
+    if latest_version?(new_resource.version)
       action :upgrade
     else
       version new_resource.version

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -25,6 +25,8 @@
 
 resource_name :sensu_backend
 
+include SensuCookbook::Helpers
+
 property :version, String, default: 'latest'
 property :repo, String, default: 'sensu/nightly'
 property :config_home, String, default: '/etc/sensu'
@@ -39,7 +41,7 @@ action :install do
   end
 
   package 'sensu-backend' do
-    if new_resource.version == 'latest'
+    if latest_version?(new_resource.version)
       action :upgrade
     else
       action :install

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -39,8 +39,12 @@ action :install do
   end
 
   package 'sensu-backend' do
-    action :install
-    version new_resource.version unless new_resource.version == 'latest'
+    if new_resource.version == 'latest'
+      action :upgrade
+    else
+      action :install
+      version new_resource.version
+    end
   end
 
   # render template at /etc/sensu/backend.yml

--- a/spec/unit/recipes/sensu_agent_spec.rb
+++ b/spec/unit/recipes/sensu_agent_spec.rb
@@ -54,7 +54,7 @@ RSpec.shared_examples 'sensu_agent' do |platform, version|
     end
 
     it 'installs package sensu-agent' do
-      expect(chef_run).to install_package('sensu-agent')
+      expect(chef_run).to upgrade_package('sensu-agent')
     end
 
     it 'enables and starts sensu-agent service' do

--- a/spec/unit/recipes/sensu_backend_spec.rb
+++ b/spec/unit/recipes/sensu_backend_spec.rb
@@ -54,7 +54,7 @@ RSpec.shared_examples 'sensu_backend' do |platform, version|
     end
 
     it 'installs package sensu-backend' do
-      expect(chef_run).to install_package('sensu-backend')
+      expect(chef_run).to upgrade_package('sensu-backend')
     end
 
     it 'enables and starts sensu-backend service' do


### PR DESCRIPTION


When specifying latest we need to ommit the version and change the action from `:install` to `:upgrade` and otherwise use the version specified and the action of `:install`.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

fixes #25 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [ ] Adedd documentation for it to the `README.md`

#### Purpose

#### Known Compatibility Issues
