### PR TITLE
Adding output_metric properties to sensu_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 ### Added
+- Adding `output_metric` settings to the `sensu_check` resource
 - new `.editorconfig` to help users who have editors that support [editor config](https://editorconfig.org/)
 - new PR and issue templates (@majormoses)
 - links to community slack (@majormoses)
@@ -18,7 +19,6 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - Added skel files from Chef Partners cookbook generator (@thomasriley)
 
 ### Changed
-- Adding `output_metric` settings to the `sensu_check` resource
 - Updated contributing instruction (@majormoses)
 - use `@sensu/chef-cookbooks` for `CODEOWNERS` rather than individual users now that there is a team to refer to instead (@majormoses)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - Added skel files from Chef Partners cookbook generator (@thomasriley)
 
 ### Changed
+- Adding `output_metric` settings to the `sensu_check` resource
 - Updated contributing instruction (@majormoses)
 - use `@sensu/chef-cookbooks` for `CODEOWNERS` rather than individual users now that there is a team to refer to instead (@majormoses)
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ The sensu_check resource is used to define check objects.
 * `subscriptions` **required** an array of Sensu entity subscriptions that check requests will be sent to, default *[]*
 * `timeout` The check execution duration timeout in seconds
 * `ttl` The value in seconds until check results are considered stale
+* `output_metric_format` (optional) the metric format that the output of this check conforms to
+* `output_metric_handlers` (optional) an array of handlers for output metrics from this check
 
 #### Examples
 ```rb

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,6 +39,8 @@ module SensuCookbook
       spec['subscriptions'] = new_resource.subscriptions
       spec['timeout'] = new_resource.timeout if new_resource.timeout
       spec['ttl'] = new_resource.ttl if new_resource.ttl
+      spec['output_metric_format'] = new_resource.output_metric_format if new_resource.output_metric_format
+      spec['output_metric_handlers'] = new_resource.output_metric_handlers if new_resource.output_metric_handlers
 
       c = {}
       c['type'] = type_from_name

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -47,6 +47,8 @@ property :subdue, Hash
 property :subscriptions, Array, default: [], required: true
 property :timeout, Integer
 property :ttl, Integer
+property :output_metric_format, String
+property :output_metric_handlers, Array
 
 action_class do
   include SensuCookbook::Helpers


### PR DESCRIPTION
## Pull Request Checklist

resolves #27 by adding output_metric_format and output_metric_handlers

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [x] Adedd documentation for it to the `README.md`

#### Purpose

#### Known Compatibility Issues
