### PR TITLE
Add sensu_user resource to provide requested feature in #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - `sensu_search` resource added (@webframp)
 - `sensu_global_config` resource to manage web ui configuration (@webframp)
 - `sensu_tessen_config` resource to manage tessen analytics preference (@webframp)
+- `sensu_user` resource to manage non SSO users (@webframp)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -870,6 +870,34 @@ sensu_tessen_config 'default' do
 end
 ```
 
+### sensu_user
+
+Manage non SSO sensu users. This resource requires a bcrypt password hash, you can use [`sensuctl user hash-password`](https://docs.sensu.io/sensu-go/latest/sensuctl/#generate-a-password-hash) to generate one.
+
+#### Properties
+
+* `username` String, username to manage.
+* `password_hash` **required**, String.
+* `groups` Array of [RBAC groups](https://docs.sensu.io/sensu-go/latest/operations/control-access/rbac/#groups) for the user
+* `disabled` enable or disable a user
+
+#### Examples
+
+``` rb
+# Disable someone who had their password exposed
+sensu_user 'doofus' do
+  password_hash '$2y$12$OrEQ61blxyTFi3PJHeJ94ej/Z857eSAnAdlSD4Kn7ywItTLrzTqVy'
+  groups %w(view admin managers)
+  disabled true
+end
+
+# Add a user with only view rights.
+sensu_user 'reinstated' do
+  password_hash '$2y$12$yga83H/KqKFKDYnLogQ6CeN3xrFmhVwMdVkh.hRPX/BhF2NJfYq8O'
+  groups %w(view)
+end
+```
+
 ## License & Authors
 
 If you would like to see the detailed LICENSE click [here](./LICENSE).

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -304,6 +304,20 @@ module SensuCookbook
       base_resource(new_resource, spec, 'core/v2')
     end
 
+    # Implemented without using base_resource method since labels aren't supported
+    def user_from_resource
+      user = Mash.new
+      user['type'] = 'User'
+      user['api_version'] = 'core/v2'
+      user['metadata'] = {}
+      user['spec'] = {}
+      user['spec']['username'] = new_resource.username
+      user['spec']['password_hash'] = new_resource.password_hash
+      user['spec']['disabled'] = new_resource.disabled if new_resource.disabled
+      user['spec']['groups'] = new_resource.groups if new_resource.groups
+      user
+    end
+
     def latest_version?(version)
       version == 'latest' || version == :latest
     end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,0 +1,74 @@
+#
+# Cookbook Name:: sensu-go
+# Resource:: user
+#
+# Copyright:: 2019 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+resource_name :sensu_user
+
+include SensuCookbook::Helpers
+include SensuCookbook::Helpers::SensuCtl
+include SensuCookbook::SensuCommonProperties
+
+property :username, String, name_property: true
+property :password, String, required: true, sensitive: true # depends on chef 12.14
+property :groups, Array, default: %w(view)
+property :disabled, [true, false], default: false
+
+action :create do
+  require 'mixlib/shellout'
+
+  # if users exists already, must call sensuctl user resinstate
+  execute "sensuctl user create #{new_resource.username}" do
+    command "#{sensuctl_bin} user create #{new_resource.username} --groups #{new_resource.groups.join(',')} --password #{new_resource.password}"
+    only_if do
+      cmd = Mixlib::ShellOut.new('sensuctl user list --format json')
+      userlist = JSON.parse(cmd.run_command.stdout)
+      user = userlist.detect { |u| u['username'] == new_resource.username }
+      user.nil?
+    end
+    sensitive true
+    action :run
+  end
+end
+
+action :delete do
+  # not possible, maybe an alias for disable?
+  puts 'no-op'
+end
+
+action :disable do
+  puts 'no-op'
+end
+
+action :reinstate do
+  puts 'no-op'
+end
+
+action :modify do
+  # an action to handle change-password, remove-group(s),add-group,set-groups
+  puts 'no-op'
+end
+
+# Tricky one
+# action :'change-password' do
+# end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: sensu-go
+# Cookbook:: sensu-go
 # Resource:: user
 #
 # Copyright:: 2019 Sensu, Inc.
@@ -24,83 +24,32 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 resource_name :sensu_user
+provides :sensu_user
 
-include SensuCookbook::Helpers
 include SensuCookbook::Helpers::SensuCtl
 include SensuCookbook::SensuCommonProperties
 
 property :username, String, name_property: true
-property :password, String, required: true, sensitive: true # depends on chef 12.14
+property :password_hash, String, required: true, sensitive: true
 property :groups, Array, default: %w(view)
 property :disabled, [true, false], default: false
 
 action_class do
-  require 'mixlib/shellout'
-  def current_users
-    cmd = Mixlib::ShellOut.new('sensuctl user list --format json')
-    JSON.parse(cmd.run_command.stdout)
-  end
-
-  def current_user
-    current_users.detect { |u| u['username'] == new_resource.username }
-  end
-
-  def exists?
-    current_users.any? { |u| u['username'] == new_resource.username }
-  end
-
-  def disabled?
-    current_users.any? { |u| u['username'] == new_resource.username && u['disabled'] == true }
-  end
-
-  def current_groups
-    current_user['groups'].sort
-  end
-
-  def group_args
-    new_resource.groups.join(',')
-  end
-
-  def groups_match?
-    current_groups == new_resource.groups.sort
-  end
+  include SensuCookbook::Helpers
 end
 
 action :create do
-  execute "sensuctl user create #{new_resource.username}" do
-    command "#{sensuctl_bin} user create #{new_resource.username} --groups #{group_args} --password #{new_resource.password}"
-    not_if { exists? }
-    sensitive true
-  end
-end
-
-action :disable do
-  execute "sensuctl user disable #{new_resource.username}" do
-    command "#{sensuctl_bin} user disable #{new_resource.username} --skip-confirm"
-    not_if { disabled? }
-  end
-end
-
-action :reinstate do
-  execute "sensuctl user reinstate #{new_resource.username}" do
-    command "#{sensuctl_bin} user reinstate #{new_resource.username}"
-    only_if { disabled? }
-  end
-end
-
-action :modify do
-  # It is difficult to make this action fully idempotent without also tracking the users passwords
-  if property_is_set?(:password)
-    execute "sensuctl user change-password #{new_resource.username}" do
-      command "sensuctl user change-password #{new_resource.username} --new-password #{password}"
-      sensitive true
-    end
+  directory object_dir do
+    action :create
+    recursive true
   end
 
-  # Instead of handling remove/add group commands just support idempotent set-group for now
-  if property_is_set?(:groups)
-    execute "sensuctl user set-groups #{new_resource.username} #{group_args}" do
-      not_if { groups_match? }
-    end
+  file object_file do
+    content JSON.generate(user_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file}]"
+  end
+
+  execute "sensuctl create -f #{object_file}" do
+    action :nothing
   end
 end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -19,6 +19,15 @@ sensu_user 'doofus' do
   groups %w(view admin)
 end
 
+sensu_user 'doofus' do
+  action :disable
+end
+
+sensu_user 'reinstated' do
+  password 'a_smart_one'
+  groups %w(view)
+  action [:create, :disable, :reinstate]
+end
 sensu_namespace 'test-org' do
   action :create
 end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -28,6 +28,12 @@ sensu_user 'reinstated' do
   groups %w(view)
   action [:create, :disable, :reinstate]
 end
+
+sensu_user 'doofus' do
+  groups %w(view admin managers)
+  action :modify
+end
+
 sensu_namespace 'test-org' do
   action :create
 end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -15,23 +15,14 @@ sensu_ctl 'default' do
 end
 
 sensu_user 'doofus' do
-  password 'doofus1234'
-  groups %w(view admin)
-end
-
-sensu_user 'doofus' do
-  action :disable
+  password_hash '$2y$12$OrEQ61blxyTFi3PJHeJ94ej/Z857eSAnAdlSD4Kn7ywItTLrzTqVy'
+  groups %w(view admin managers)
+  disabled true
 end
 
 sensu_user 'reinstated' do
-  password 'a_smart_one'
+  password_hash '$2y$12$yga83H/KqKFKDYnLogQ6CeN3xrFmhVwMdVkh.hRPX/BhF2NJfYq8O'
   groups %w(view)
-  action [:create, :disable, :reinstate]
-end
-
-sensu_user 'doofus' do
-  groups %w(view admin managers)
-  action :modify
 end
 
 sensu_namespace 'test-org' do

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -14,6 +14,11 @@ sensu_ctl 'default' do
   debug true
 end
 
+sensu_user 'doofus' do
+  password 'doofus1234'
+  groups %w(view admin)
+end
+
 sensu_namespace 'test-org' do
   action :create
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -47,6 +47,7 @@ describe json(command: 'sensuctl user list --format json') do
   its([1, 'username']) { should cmp 'agent' }
   its([2, 'username']) { should cmp 'doofus' }
   its([2, 'groups']) { should include 'admin' }
+  its([2, 'groups']) { should include 'managers' }
   its([2, 'disabled']) { should cmp 'true' }
   its([3, 'username']) { should cmp 'reinstated' }
   its([3, 'groups']) { should include 'view' }

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -40,6 +40,19 @@ describe command('sensuctl user list') do
   its('exit_status') { should eq 0 }
 end
 
+describe json(command: 'sensuctl user list --format json') do
+  # Referrencing returned elements of the array by index feels fragile
+  its([0, 'username']) { should cmp 'admin' }
+  its([0, 'disabled']) { should cmp 'false' }
+  its([1, 'username']) { should cmp 'agent' }
+  its([2, 'username']) { should cmp 'doofus' }
+  its([2, 'groups']) { should include 'admin' }
+  its([2, 'disabled']) { should cmp 'true' }
+  its([3, 'username']) { should cmp 'reinstated' }
+  its([3, 'groups']) { should include 'view' }
+  its([3, 'disabled']) { should cmp 'false' }
+end
+
 describe json('/etc/sensu/checks/cron.json') do
   its(%w(type)) { should eq 'Check' }
   its(%w(metadata name)) { should eq 'cron' }


### PR DESCRIPTION
This is an early start at a design for the sensu_user resource. There's plenty
of room for questions based on the community needs.

Much refactoring is still needed.

Note that the use of a sensitive resource property bumps the minimum required
chef version to 12.14. As this version was released more than 2 years ago in
late 2016 I believe this is a safe assumption.

* https://docs.chef.io/release_notes.html#sensitive-true
* https://github.com/chef/chef/blob/master/CHANGELOG.md#v121460-2016-09-09

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [x] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [x] Adedd documentation for it to the `README.md`

#### Purpose

Adds `sensu_user` resource for user manage via sensuctl commands.

#### Known Compatibility Issues

This breaks compatibility with chef-client versions prior to 12.14 that do not support `sensitive: true` on custom resource properties