### PR TITLE
add a debug option for `sensu_ctl` resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,9 @@ driver:
 
 provisioner:
   name: chef_zero
+  client_rb:
+    chef_client:
+      chef_license: accept
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,7 @@ driver:
 provisioner:
   name: chef_zero
   client_rb:
-    chef_client:
-      chef_license: accept
+    chef_license: accept
 
 verifier:
   name: inspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ branches:
 services: docker
 
 env:
+  global:
+  - CHEF_LICENSE="accept-no-persist"
   matrix:
   - INSTANCE=default-centos-6
   - INSTANCE=default-centos-7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ## [Unreleased]
 ### Added
 - Most resources now support metadata specific properties (@webframp)
+- add `debug` option for `sensu_ctl` resource to help debug (@majormoses)
 
 ### Changed
 - sensuctl cli args for asset updates now uses `--namespace`

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'chef-sugar'
 group :development do
   gem 'foodcritic'
   gem 'chefspec'
-  gem 'cookstyle'
+  gem 'cookstyle', '~> 4.0'
   gem 'guard'
   gem 'guard-foodcritic'
   gem 'guard-rubocop'

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -30,6 +30,9 @@ include SensuCookbook::SensuPackageProperties
 property :username, String, default: 'admin'
 property :password, String, default: 'P@ssw0rd!'
 property :backend_url, String, default: 'http://127.0.0.1:8080'
+# WARNING: this will expose secrets to whatever is capturing
+# the log output be it stdout (such as in CI) or log files
+property :debug, [TrueClass, FalseClass], default: false
 
 action_class do
   include SensuCookbook::Helpers::SensuCtl
@@ -45,7 +48,7 @@ end
 action :install do
   packagecloud_repo new_resource.repo do
     type value_for_platform_family(
-      %w(rhel fedora amazon) => 'rpm',
+      %w[rhel fedora amazon] => 'rpm',
       'default' => 'deb'
     )
   end
@@ -61,7 +64,7 @@ action :configure do
     converge_by 'Reconfiguring sensuctl' do
       execute 'configure sensuctl' do
         command sensuctl_configure_cmd
-        sensitive true
+        sensitive new_resource.debug
       end
     end
   end

--- a/spec/unit/recipes/sensu_agent_spec.rb
+++ b/spec/unit/recipes/sensu_agent_spec.rb
@@ -67,7 +67,7 @@ end
 RSpec.describe 'sensu_test::default' do
   platforms = {
     'ubuntu' => ['14.04', '16.04'],
-    'centos' =>  '7.3.1611',
+    'centos' => '7.3.1611',
   }
 
   platforms.each do |platform, versions|

--- a/spec/unit/recipes/sensu_backend_spec.rb
+++ b/spec/unit/recipes/sensu_backend_spec.rb
@@ -67,7 +67,7 @@ end
 RSpec.describe 'sensu_test::default' do
   platforms = {
     'ubuntu' => ['14.04', '16.04'],
-    'centos' =>  '7.3.1611',
+    'centos' => '7.3.1611',
   }
 
   platforms.each do |platform, versions|

--- a/spec/unit/recipes/sensu_check_spec.rb
+++ b/spec/unit/recipes/sensu_check_spec.rb
@@ -60,7 +60,7 @@ end
 RSpec.describe 'sensu_test::default' do
   platforms = {
     'ubuntu' => ['14.04', '16.04'],
-    'centos' =>  '7.3.1611',
+    'centos' => '7.3.1611',
   }
 
   platforms.each do |platform, versions|

--- a/spec/unit/recipes/sensu_ctl_spec.rb
+++ b/spec/unit/recipes/sensu_ctl_spec.rb
@@ -60,7 +60,7 @@ end
 RSpec.describe 'sensu_test::default' do
   platforms = {
     'ubuntu' => ['14.04', '16.04'],
-    'centos' =>  '7.3.1611',
+    'centos' => '7.3.1611',
   }
 
   platforms.each do |platform, versions|


### PR DESCRIPTION
This is useful for debugging but should be done with extreme caution as it could increase the likelihood of secrets being exposed where they need not be.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://sensucommunity.slack.com/archives/C9BB9AW7K/p1556243025188500

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### Purpose
Allow users to toggle additional unsafe debug

#### Known Compatibility Issues
none