### PR TITLE
Sensu-Go-Agent support for windows platform

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,9 +16,33 @@ platforms:
   - name: ubuntu-18.04
   - name: centos-6
   - name: centos-7
+  - name: windows-2012r2
+    driver:
+      box: tas50/windows-2012r2  
+  - name: windows-2016
+    driver:
+      box: tas50/windows_2016
+      customize:
+        memory: 3072
+  - name: windows-2019
+    driver:
+      box: tas50/windows_2016
+      customize:
+        memory: 3072
 
 suites:
   - name: default
     run_list:
       - recipe[sensu_test::default]
+    attributes:
+    excludes:
+      - windows-2012r2
+      - windows-2016
+      - windows-2019
+  - name: agent
+    run_list:
+      - recipe[sensu_test::agent]
+    verifier:
+      inspec_tests:
+        - test/integration/agent
     attributes:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,5 @@ Style/FrozenStringLiteralComment:
 Lint/AmbiguousRegexpLiteral:
   Exclude:
     - '**/test/**/*'
+Layout/EndOfLine:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - Most resources now support metadata specific properties (@webframp)
 - add `sensu_hook` resource (@derekgroh)
 - add `debug` option for `sensu_ctl` resource to help debug (@majormoses)
+- add support for sensu-go-agent on windows platform (@derekgroh)
 
 ### Changed
 - sensuctl cli args for asset updates now uses `--namespace`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The following platforms have been tested with Test Kitchen. It will most likely 
 | fedora        | X     |
 | ubuntu-14.04  | X     |
 | ubuntu-16.04  | X     |
+| windows-2012r2 | Agent Only |
+| windows-2016 | Agent Only |
+| windows-2019 | Agent Only |
 
 ## Cookbook Dependencies
 
@@ -149,6 +152,7 @@ end
 ```
 ### sensu_agent
 The sensu agent resource will install and configure the agent.
+**NOTE:** windows agent install is pinned to version 5.10 until available in a consumable package format (likely chocolately)
 #### Properties
 * `version` which version to install, default: *latest*
 * `repo` which repo to pull package from, default: *sensu/stable*

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -35,32 +35,66 @@ property :config, Hash, default: { "name": node['hostname'],
                                    "backend-url": ['ws://127.0.0.1:8081'],
                                  }
 action :install do
-  packagecloud_repo new_resource.repo do
-    type value_for_platform_family(
-      %w(rhel fedora amazon) => 'rpm',
-      'default' => 'deb'
-    )
-  end
+  # Linux installation - source package
+  if node['platform'] != 'windows'
+    packagecloud_repo new_resource.repo do
+      type value_for_platform_family(
+        %w(rhel fedora amazon) => 'rpm',
+        'default' => 'deb'
+      )
+    end
 
-  package 'sensu-go-agent' do
-    if latest_version?(new_resource.version)
-      action :upgrade
-    else
-      version new_resource.version
-      action :install
+    # Installs/upgrades sensu-go-agent package
+    package 'sensu-go-agent' do
+      if latest_version?(new_resource.version)
+        action :upgrade
+      else
+        version new_resource.version
+        action :install
+      end
+    end
+
+    # render template at /etc/sensu/agent.yml for linux
+    file ::File.join(new_resource.config_home, 'agent.yml') do
+      content(stringify_keys(new_resource.config))
+    end
+
+    # Enable and start the sensu-agent service
+    service 'sensu-agent' do
+      if node['platform'] == 'ubuntu' && node['platform_version'].to_f == 14.04
+        provider Chef::Provider::Service::Init
+        action :start
+      else
+        action [:enable, :start]
+      end
     end
   end
 
-  # render template at /etc/sensu/agent.yml
-  file ::File.join(new_resource.config_home, 'agent.yml') do
-    content(stringify_keys(new_resource.config))
-  end
+  # Installs msi for Sensu-Go
+  if node['platform'] == 'windows'
+    windows_package 'sensu-go-agent' do
+      source 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.10.0/sensu-go-agent_5.10.0.4171_en-US.x64.msi'
+      installer_type :custom
+      version '5.10.0.4171'
+    end
 
-  service 'sensu-agent' do
-    if node['platform'] == 'ubuntu' && node['platform_version'].to_f == 14.04
-      provider Chef::Provider::Service::Init
-      action :start
-    else
+    # Adds install directory to path
+    windows_path 'c:\\Program Files\\sensu\\sensu-agent\\bin'
+
+    # render template at c:\Programdata\Sensu\config\agent.yml for windows
+    file ::File.join('c:/ProgramData/Sensu/config', 'agent.yml') do
+      content(stringify_keys(new_resource.config))
+    end
+
+    # Installs SensuAgent Service
+    powershell_script 'SensuAgent Service' do
+      code '.\\sensu-agent.exe service install'
+      cwd 'c:/Program Files/sensu/sensu-agent/bin'
+      not_if '((Get-Service SensuAgent).Name -eq "SensuAgent")'
+    end
+
+    # Enable and start SensuAgent service
+    service 'SensuAgent' do
       action [:enable, :start]
     end
   end

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -8,6 +8,8 @@ RSpec.shared_context 'common_stubs' do
 
   before do
     stub_data_bag_item('sensu', 'assets').and_return(assets_stub)
+    # rubocop:disable Style/StringLiterals
+    stub_command("((Get-Service SensuAgent).Name -eq \"SensuAgent\")")
   end
 end
 

--- a/spec/unit/recipes/sensu_agent_spec.rb
+++ b/spec/unit/recipes/sensu_agent_spec.rb
@@ -24,7 +24,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-RSpec.shared_examples 'sensu_agent_nix' do |platform, version|
+RSpec.shared_examples 'sensu_agent' do |platform, version|
   context "when run on #{platform} #{version}" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(
@@ -116,7 +116,7 @@ RSpec.describe 'sensu_test::default' do
   nix_platforms.each do |platform, versions|
     versions = versions.is_a?(String) ? [versions] : versions
     versions.each do |version|
-      include_examples 'sensu_agent_nix', platform, version
+      include_examples 'sensu_agent', platform, version
     end
   end
 

--- a/spec/unit/recipes/sensu_agent_spec.rb
+++ b/spec/unit/recipes/sensu_agent_spec.rb
@@ -24,7 +24,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-RSpec.shared_examples 'sensu_agent' do |platform, version|
+RSpec.shared_examples 'sensu_agent_nix' do |platform, version|
   context "when run on #{platform} #{version}" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(
@@ -64,16 +64,66 @@ RSpec.shared_examples 'sensu_agent' do |platform, version|
   end
 end
 
+RSpec.shared_examples 'sensu_agent_win' do |platform, version|
+  context "when run on #{platform} #{version}" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        os: 'windows',
+        platform: platform,
+        version: version,
+        step_into: ['sensu_agent']
+      ).converge(described_recipe)
+    end
+
+    include_context 'common_stubs'
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'installs package sensu agent' do
+      expect(chef_run).to install_windows_package('sensu-go-agent')
+    end
+
+    it 'adds a path to windows variable' do
+      expect(chef_run).to add_windows_path('c:\Program Files\sensu\sensu-agent\bin')
+    end
+
+    it 'writes the agent config file' do
+      expect(chef_run).to create_file('c:/ProgramData/Sensu/config/agent.yml')
+    end
+
+    it 'runs a powershell script' do
+      expect(chef_run).to run_powershell_script('SensuAgent Service')
+    end
+
+    it 'enables and starts sensuagent service' do
+      expect(chef_run).to enable_service('SensuAgent')
+      expect(chef_run).to start_service('SensuAgent')
+    end
+  end
+end
+
 RSpec.describe 'sensu_test::default' do
-  platforms = {
+  nix_platforms = {
     'ubuntu' => ['14.04', '16.04'],
     'centos' => '7.3.1611',
   }
+  win_platforms = {
+    'windows' => %w(2012r2 2016 2019),
+  }
 
-  platforms.each do |platform, versions|
+  nix_platforms.each do |platform, versions|
     versions = versions.is_a?(String) ? [versions] : versions
     versions.each do |version|
-      include_examples 'sensu_agent', platform, version
+      include_examples 'sensu_agent_nix', platform, version
+    end
+  end
+
+  win_platforms.each do |platform, versions|
+    versions = versions.is_a?(String) ? [versions] : versions
+    versions.each do |version|
+      include_examples 'sensu_agent_win', platform, version
     end
   end
 end

--- a/test/cookbooks/sensu_test/recipes/agent.rb
+++ b/test/cookbooks/sensu_test/recipes/agent.rb
@@ -1,0 +1,1 @@
+sensu_agent 'default'

--- a/test/integration/agent/agent_spec.rb
+++ b/test/integration/agent/agent_spec.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: sensu-go
+# Spec:: agent
+#
+# Copyright:: 2019, The Authors, All Rights Reserved.
+
+# The following are only examples, check out https://github.com/chef/inspec/tree/master/docs
+# for everything you can do.
+if os.linux?
+  if os.redhat? || os.name == 'fedora' || os.name == 'amazon'
+    describe yum.repo('sensu_stable') do
+      it { should exist }
+      it { should be_enabled }
+    end
+  end
+
+  if os.name == 'debian' || os.name == 'ubuntu'
+    describe apt("https://packagecloud.io/sensu/stable/#{os.name}") do
+      it { should exist }
+      it { should be_enabled }
+    end
+  end
+
+  describe package('sensu-go-agent') do
+    it { should be_installed }
+  end
+
+  describe service('sensu-agent') do
+    it { should be_installed }
+    # Ubuntu 14.04: Sensu pkg ships an init script, init provider doesn't support enable
+    it { should be_enabled unless os.release.to_f == 14.04 }
+    it { should be_running }
+  end
+end
+
+if os.windows?
+  describe package('sensu agent') do
+    it { should be_installed }
+  end
+
+  describe service('sensuagent') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

#46 - Add support for installing Sensu Agent MSI on Windows

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Foodcritic passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose
Allows cookbook to handle installation and configuration of the [Windows (5.10.0)](https://sensu.io/products/downloads) MSI.

#### Known Compatibility Issues
Long term implementation does not support using the latest version, until a package mechanism is created. This will most likely occur via [Chocolatey](https://chocolatey.org/) in the future.