### PR TITLE
add sensu_agent example with non-default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ The sensu agent resource will install and configure the agent.
 sensu_agent 'default'
 ```
 
+**(insecure example, don't really do this)**
+
+```rb
+sensu_agent 'default' do
+  config(
+    "name": node['fqdn'],
+    "namespace": "default",
+    "backend-url": ["wss://sensu-backend.example.com:8081"],
+    "insecure-skip-tls-verify": true,
+    "subscriptions": ["centos", "haproxy"],
+    "labels": {
+      "app_id": "mycoolapp",
+      "app_tier": "loadbalancer"
+    },
+    "annotations": {
+      "color": "green"
+    }
+  )
+end
+```
+
 ### sensu_ctl
 Installs and configures the sensuctl cli
 #### Properties


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [ ] Added documentation for it to the `README.md`

#### Purpose

Adds an example to the `sensu_agent` section of the readme which illustrates use of the `config` parameter to set non-default values for backend-url, subscriptions, labels, annotations, etc.

#### Known Compatibility Issues
