### PR TITLE
Fix sensu_ctl command escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ### Changed
 - sensuctl cli args for asset updates now uses `--namespace`
-- sensuctl cli args are escaped properly
-- sensuctl cli commands are marked sensitive by default
+- sensuctl cli args are escaped properly (@beeerd)
+- sensuctl cli commands are marked sensitive by default (@beeerd)
 
 ### Breaking Changes
 - Use stable package channels (@webframp)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ### Changed
 - sensuctl cli args for asset updates now uses `--namespace`
+- sensuctl cli args are escaped properly
+- sensuctl cli commands are marked sensitive by default
 
 ### Breaking Changes
 - Use stable package channels (@webframp)

--- a/libraries/helpers_sensuctl.rb
+++ b/libraries/helpers_sensuctl.rb
@@ -8,23 +8,23 @@ module SensuCookbook
       def sensuctl_configure_opts
         opts = []
         opts << '--non-interactive'
-        opts << "--username #{new_resource.username}" unless new_resource.username.nil?
-        opts << "--password #{new_resource.password}" unless new_resource.password.nil?
-        opts << "--url #{new_resource.backend_url}" unless new_resource.backend_url.nil?
+        opts << ['--username', new_resource.username] unless new_resource.username.nil?
+        opts << ['--password', new_resource.password] unless new_resource.password.nil?
+        opts << ['--url', new_resource.backend_url] unless new_resource.backend_url.nil?
         opts
       end
 
       def sensuctl_configure_cmd
-        [sensuctl_bin, 'configure', sensuctl_configure_opts].join(' ').strip
+        [sensuctl_bin, 'configure', sensuctl_configure_opts].flatten
       end
 
       def sensuctl_asset_update_opts
         opts = []
-        opts << "--namespace #{new_resource.namespace}" if new_resource.namespace
+        opts << ['--namespace', new_resource.namespace] if new_resource.namespace
       end
 
       def sensuctl_asset_update_cmd
-        [sensuctl_bin, 'asset', 'update', new_resource.name, sensuctl_asset_update_opts].join(' ').strip
+        [sensuctl_bin, 'asset', 'update', new_resource.name, sensuctl_asset_update_opts].flatten
       end
     end
   end

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -28,7 +28,7 @@ resource_name :sensu_ctl
 include SensuCookbook::SensuPackageProperties
 
 property :username, String, default: 'admin'
-property :password, String, default: 'P@ssw0rd!'
+property :password, String, default: 'P@ssw0rd!', sensitive: true
 property :backend_url, String, default: 'http://127.0.0.1:8080'
 # WARNING: this will expose secrets to whatever is capturing
 # the log output be it stdout (such as in CI) or log files
@@ -64,7 +64,7 @@ action :configure do
     converge_by 'Reconfiguring sensuctl' do
       execute 'configure sensuctl' do
         command sensuctl_configure_cmd
-        sensitive new_resource.debug
+        sensitive true unless new_resource.debug
       end
     end
   end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -4,6 +4,7 @@ sensu_agent 'default'
 
 sensu_ctl 'default' do
   action [:install, :configure]
+  debug true
 end
 
 sensu_namespace 'test-org' do


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes


#### Purpose

This PR addresses issue #60 

#### Known Compatibility Issues

None