### PR TITLE
Add `runtime_assets` property to `filters` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `filters` resource now supports `runtime_assets` being passed (@majormoses)
 
 ## [0.1.0] - 2019-09-16
 ### Added

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -115,6 +115,7 @@ module SensuCookbook
       spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['expressions'] = new_resource.expressions
       spec['when'] = new_resource.when if new_resource.when
+      spec['runtime_assets'] = new_resource.runtime_assets if new_resource.runtime_assets
 
       f = {}
       f['type'] = 'event_' + type_from_name

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -31,6 +31,7 @@ resource_name :sensu_filter
 property :filter_action, String, equal_to: %w(allow deny), required: true
 property :expressions, Array, required: true
 property :when, Hash
+property :runtime_assets, Array
 
 action_class do
   include SensuCookbook::Helpers


### PR DESCRIPTION
## Pull Request Checklist

closes #64 @webframp I took a quick look and I did not see any tests for filters, am I missing something or did they not get done. I can take a closer look over the weekend possibly. I also need to actually look more closely at the docs since it was not clear to me what

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [ ] Adedd documentation for it to the `README.md`

#### Purpose

Add support for `runttime_assets` on `filters`.

API Docs: https://docs.sensu.io/sensu-go/5.13/api/filters/

#### Known Compatibility Issues
none