### PR TITLE
Update readme state-file path to match actual default

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The sensu backend resource can configure the core sensu backend service.
 * `version` which version to install, default: *latest*
 * `repo` which repo to pull package from, default: *sensu/stable*
 * `config_home` where to store the generated object definitions, default: */etc/sensu*
-* `config` a hash of configuration, default: *{ 'state-dir': '/var/lib/sensu'}*
+* `config` a hash of configuration, default: *{ 'state-dir': '/var/lib/sensu/sensu-backend'}*
 
 #### Examples
 ```rb
@@ -146,7 +146,7 @@ Optionally pass configuration values for the backend:
 ```rb
 sensu_backend 'default' do
   repo 'sensu/stable'
-  config({'state-dir' => '/var/lib/sensu',
+  config({'state-dir' => '/var/lib/sensu/sensu-backend',
           'trusted-ca-file' => "/some/local/path.pem",
           'insecure-skip-tls-verify' => true})
 end


### PR DESCRIPTION
If you follow the README and set state-dir path to "/var/lib/sensu" bad things happen. The actual default is "/var/lib/sensu/sensu-backend" and we should reflect that in the README.
Signed-off-by: Nathan Haneysmith <nathan@chef.io>

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes
No (but not because of README)

- [ ] Foodcritic passes
(foodcritic is depreciated)

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [x] Adedd documentation for it to the `README.md`

#### Purpose
Just updating documentation to reflect proper default value.

#### Known Compatibility Issues
