### PR TITLE
Refactor helpers to use a common base_resource method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored resource helpers to reduce duplication. (@cwjohnston) - #72
+
 ### Added
 
 - `filters` resource now supports `runtime_assets` being passed (@majormoses)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -141,8 +141,9 @@ module SensuCookbook
       spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['entity_class'] = new_resource.entity_class
 
-      e = {}
+      e = base_resource(new_resource, spec)
       e['type'] = type_from_name
+      e['metadata']['namespace'] = new_resource.namespace
       e['spec'] = spec
       e
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -36,11 +36,6 @@ module SensuCookbook
       spec['check_hooks'] = new_resource.check_hooks if new_resource.check_hooks
       spec['command'] = new_resource.command
       spec['cron'] = new_resource.cron
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['handlers'] = new_resource.handlers
       spec['high_flap_threshold'] = new_resource.high_flap_threshold if new_resource.high_flap_threshold
       spec['interval'] = new_resource.interval if new_resource.interval
@@ -58,8 +53,9 @@ module SensuCookbook
       spec['output_metric_format'] = new_resource.output_metric_format if new_resource.output_metric_format
       spec['output_metric_handlers'] = new_resource.output_metric_handlers if new_resource.output_metric_handlers
 
-      c = {}
-      c['type'] = type_from_name
+      c = base_resource(new_resource, spec)
+      c['metadata']['namespace'] = new_resource.namespace
+      c['metadata']['type'] = type_from_name
       c['spec'] = spec
       c
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -124,11 +124,6 @@ module SensuCookbook
     def entity_from_resource
       spec = {}
       spec['subscriptions'] = new_resource.subscriptions
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['entity_class'] = new_resource.entity_class
 
       e = base_resource(new_resource, spec)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -179,12 +179,6 @@ module SensuCookbook
     end
 
     def role_binding_from_resource
-      binding = {
-        'type' => type_from_name,
-        'metadata' => {},
-        'spec' => {},
-      }
-
       spec = {
         'role_ref' => {
           'name' => new_resource.role_name,
@@ -193,7 +187,8 @@ module SensuCookbook
         'subjects' => new_resource.subjects,
       }
 
-      binding['metadata']['name'] = new_resource.name
+      binding = base_resource(new_resource, spec)
+      binding['type'] = type_from_name
       binding['metadata']['namespace'] = new_resource.namespace
       binding['spec'] = spec
       binding

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -76,11 +76,6 @@ module SensuCookbook
       spec = {}
       spec['command'] = new_resource.command if new_resource.command
       spec['env_vars'] = new_resource.env_vars if new_resource.env_vars
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['filters'] = new_resource.filters if new_resource.filters
       spec['handlers'] = new_resource.handlers if new_resource.handlers
       spec['mutator'] = new_resource.mutator if new_resource.mutator
@@ -89,8 +84,9 @@ module SensuCookbook
       spec['timeout'] = new_resource.timeout if new_resource.timeout
       spec['type'] = new_resource.type
 
-      h = {}
+      h = base_resource(new_resource, spec)
       h['type'] = type_from_name
+      h['metadata']['namespace'] = new_resource.namespace
       h['spec'] = spec
       h
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -137,11 +137,10 @@ module SensuCookbook
     end
 
     def namespace_from_resource
-      spec = {}
-      spec['name'] = new_resource.name
-
-      e = {}
-      e['type'] = type_from_name
+      e = {
+        'type' => type_from_name,
+        'spec' => { 'name' => new_resource.name },
+      }
       e
     end
 
@@ -187,7 +186,6 @@ module SensuCookbook
       }
 
       cbinding = base_resource(new_resource, spec)
-      cbinding['metadata']['namespace'] = new_resource.namespace
       cbinding
     end
 
@@ -195,7 +193,7 @@ module SensuCookbook
       spec = {
         'dsn' => new_resource.dsn,
       }
-      spec['pool_size'] if new_resource.pool_size
+      spec['pool_size'] = new_resource.pool_size if new_resource.pool_size
       obj = base_resource(new_resource, spec)
       obj['api_version'] = 'store/v1'
       obj

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -211,16 +211,13 @@ module SensuCookbook
     end
 
     def postgres_cfg_from_resource
-      obj = {
-        'metadata' => {},
-        'spec' => {},
+      spec = {
+        'dsn' => new_resource.dsn,
       }
-      obj['type'] = 'PostgresConfig'
+      spec['pool_size'] if new_resource.pool_size
+      obj = base_resource(new_resource, spec)
+      obj['type'] = type_from_name
       obj['api_version'] = 'store/v1'
-      obj['metadata']['name'] = new_resource.name
-      obj['spec']['dsn'] = new_resource.dsn
-      obj['spec']['pool_size'] = new_resource.pool_size if new_resource.pool_size
-
       obj
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -195,12 +195,6 @@ module SensuCookbook
     end
 
     def cluster_role_binding_from_resource
-      cbinding = {
-        'type' => type_from_name,
-        'metadata' => {},
-        'spec' => {},
-      }
-
       spec = {
         'role_ref' => {
           'name' => new_resource.role_name,
@@ -209,7 +203,9 @@ module SensuCookbook
         'subjects' => new_resource.subjects,
       }
 
-      cbinding['metadata']['name'] = new_resource.name
+      cbinding = base_resource(new_resource, spec)
+      cbinding['type'] = type_from_name
+      cbinding['metadata']['namespace'] = new_resource.namespace
       cbinding['spec'] = spec
       cbinding
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -107,17 +107,13 @@ module SensuCookbook
     def filter_from_resource
       spec = {}
       spec['action'] = new_resource.filter_action
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['expressions'] = new_resource.expressions
       spec['when'] = new_resource.when if new_resource.when
       spec['runtime_assets'] = new_resource.runtime_assets if new_resource.runtime_assets
 
-      f = {}
+      f = base_resource(new_resource, spec)
       f['type'] = 'Event' + type_from_name
+      f['metadata']['namespace'] = new_resource.namespace
       f['spec'] = spec
       f
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -122,15 +122,11 @@ module SensuCookbook
       spec = {}
       spec['command'] = new_resource.command
       spec['env_vars'] = new_resource.env_vars if new_resource.env_vars
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['timeout'] = new_resource.timeout if new_resource.timeout
 
-      m = {}
+      m = base_resource(new_resource, spec)
       m['type'] = type_from_name
+      m['metadata']['namespace'] = new_resource.namespace
       m['spec'] = spec
       m
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -25,7 +25,7 @@ module SensuCookbook
       meta['annotations'] = new_resource.annotations if new_resource.annotations
 
       obj['metadata'] = meta
-      obj['spec'] = spec
+      obj['type'] = type_from_name
       obj
     end
 
@@ -55,8 +55,6 @@ module SensuCookbook
 
       c = base_resource(new_resource, spec)
       c['metadata']['namespace'] = new_resource.namespace
-      c['metadata']['type'] = type_from_name
-      c['spec'] = spec
       c
     end
 
@@ -67,8 +65,6 @@ module SensuCookbook
 
       a = base_resource(new_resource, spec)
       a['metadata']['namespace'] = new_resource.namespace
-      a['type'] = type_from_name
-      a['spec'] = spec
       a
     end
 
@@ -85,9 +81,7 @@ module SensuCookbook
       spec['type'] = new_resource.type
 
       h = base_resource(new_resource, spec)
-      h['type'] = type_from_name
       h['metadata']['namespace'] = new_resource.namespace
-      h['spec'] = spec
       h
     end
 
@@ -98,9 +92,7 @@ module SensuCookbook
       spec['stdin'] = new_resource.stdin if new_resource.stdin
 
       h = base_resource(new_resource, spec)
-      h['type'] = type_from_name
       h['metadata']['namespace'] = new_resource.namespace
-      h['spec'] = spec
       h
     end
 
@@ -114,7 +106,6 @@ module SensuCookbook
       f = base_resource(new_resource, spec)
       f['type'] = 'Event' + type_from_name
       f['metadata']['namespace'] = new_resource.namespace
-      f['spec'] = spec
       f
     end
 
@@ -125,9 +116,7 @@ module SensuCookbook
       spec['timeout'] = new_resource.timeout if new_resource.timeout
 
       m = base_resource(new_resource, spec)
-      m['type'] = type_from_name
       m['metadata']['namespace'] = new_resource.namespace
-      m['spec'] = spec
       m
     end
 
@@ -142,9 +131,7 @@ module SensuCookbook
       spec['entity_class'] = new_resource.entity_class
 
       e = base_resource(new_resource, spec)
-      e['type'] = type_from_name
       e['metadata']['namespace'] = new_resource.namespace
-      e['spec'] = spec
       e
     end
 
@@ -154,7 +141,6 @@ module SensuCookbook
 
       e = {}
       e['type'] = type_from_name
-      e['spec'] = spec
       e
     end
 
@@ -164,7 +150,6 @@ module SensuCookbook
       }
 
       role = base_resource(new_resource, spec)
-      role['type'] = type_from_name
       role['metadata']['namespace'] = new_resource.namespace
       role
     end
@@ -174,7 +159,6 @@ module SensuCookbook
         'rules' => new_resource.rules,
       }
       crole = base_resource(new_resource, spec)
-      crole['type'] = type_from_name
       crole
     end
 
@@ -188,9 +172,7 @@ module SensuCookbook
       }
 
       binding = base_resource(new_resource, spec)
-      binding['type'] = type_from_name
       binding['metadata']['namespace'] = new_resource.namespace
-      binding['spec'] = spec
       binding
     end
 
@@ -204,9 +186,7 @@ module SensuCookbook
       }
 
       cbinding = base_resource(new_resource, spec)
-      cbinding['type'] = type_from_name
       cbinding['metadata']['namespace'] = new_resource.namespace
-      cbinding['spec'] = spec
       cbinding
     end
 
@@ -216,7 +196,6 @@ module SensuCookbook
       }
       spec['pool_size'] if new_resource.pool_size
       obj = base_resource(new_resource, spec)
-      obj['type'] = type_from_name
       obj['api_version'] = 'store/v1'
       obj
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -159,14 +159,13 @@ module SensuCookbook
     end
 
     def role_from_resource
-      role = {
-        'type' => type_from_name,
-        'metadata' => {},
-        'spec' => {},
+      spec = {
+        'rules' => new_resource.rules,
       }
-      role['metadata']['name'] = new_resource.name
+
+      role = base_resource(new_resource, spec)
+      role['type'] = type_from_name
       role['metadata']['namespace'] = new_resource.namespace
-      role['spec']['rules'] = new_resource.rules
       role
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -170,14 +170,11 @@ module SensuCookbook
     end
 
     def cluster_role_from_resource
-      crole = {
-        'type' => type_from_name,
-        'metadata' => {},
-        'spec' => {},
+      spec = {
+        'rules' => new_resource.rules,
       }
-
-      crole['metadata']['name'] = new_resource.name
-      crole['spec']['rules'] = new_resource.rules
+      crole = base_resource(new_resource, spec)
+      crole['type'] = type_from_name
       crole
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -62,15 +62,11 @@ module SensuCookbook
 
     def asset_from_resource
       spec = {}
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
       spec['sha512'] = new_resource.sha512
       spec['url'] = new_resource.url
 
-      a = {}
+      a = base_resource(new_resource, spec)
+      a['metadata']['namespace'] = new_resource.namespace
       a['type'] = type_from_name
       a['spec'] = spec
       a

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,6 +26,7 @@ module SensuCookbook
 
       obj['metadata'] = meta
       obj['type'] = type_from_name
+      obj['spec'] = spec
       obj
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -96,14 +96,10 @@ module SensuCookbook
       spec['command'] = new_resource.command if new_resource.command
       spec['timeout'] = new_resource.timeout if new_resource.timeout
       spec['stdin'] = new_resource.stdin if new_resource.stdin
-      spec['metadata'] = {}
-      spec['metadata']['name'] = new_resource.name
-      spec['metadata']['namespace'] = new_resource.namespace
-      spec['metadata']['labels'] = new_resource.labels if new_resource.labels
-      spec['metadata']['annotations'] = new_resource.annotations if new_resource.annotations
 
-      h = {}
+      h = base_resource(new_resource, spec)
       h['type'] = type_from_name
+      h['metadata']['namespace'] = new_resource.namespace
       h['spec'] = spec
       h
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -190,8 +190,7 @@ module SensuCookbook
         'dsn' => new_resource.dsn,
       }
       spec['pool_size'] = new_resource.pool_size if new_resource.pool_size
-      obj = base_resource(new_resource, spec)
-      obj['api_version'] = 'store/v1'
+      obj = base_resource(new_resource, spec, 'store/v1')
       obj
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,6 +16,19 @@ module SensuCookbook
       ::File.join(object_dir, new_resource.name) + '.json'
     end
 
+    def base_resource(new_resource, spec = Mash.new)
+      obj = Mash.new
+      meta = Mash.new
+
+      meta['name'] = new_resource.name
+      meta['labels'] = new_resource.labels if new_resource.labels
+      meta['annotations'] = new_resource.annotations if new_resource.annotations
+
+      obj['metadata'] = meta
+      obj['spec'] = spec
+      obj
+    end
+
     # Get check properties from the resource
     # https://docs.sensu.io/sensu-core/2.0/reference/checks/#check-attributes
     def check_from_resource

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -16,7 +16,7 @@ module SensuCookbook
       ::File.join(object_dir, new_resource.name) + '.json'
     end
 
-    def base_resource(new_resource, spec = Mash.new)
+    def base_resource(new_resource, spec = Mash.new, api_version = 'core/v2')
       obj = Mash.new
       meta = Mash.new
 
@@ -26,6 +26,7 @@ module SensuCookbook
 
       obj['metadata'] = meta
       obj['type'] = type_from_name
+      obj['api_version'] = api_version
       obj['spec'] = spec
       obj
     end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -42,9 +42,9 @@ end
 
 describe json('/etc/sensu/checks/cron.json') do
   its(%w(type)) { should eq 'Check' }
-  its(%w(spec metadata name)) { should eq 'cron' }
-  its(%w(spec metadata namespace)) { should eq 'default' }
-  its(%w(spec metadata annotations runbook)) { should eq 'https://www.xkcd.com/378/' }
+  its(%w(metadata name)) { should eq 'cron' }
+  its(%w(metadata namespace)) { should eq 'default' }
+  its(%w(metadata annotations runbook)) { should eq 'https://www.xkcd.com/378/' }
   its(%w(spec cron)) { should eq '@hourly' }
   its(%w(spec subscriptions)) { should include 'dad_jokes' }
   its(%w(spec subscriptions)) { should include 'production' }
@@ -60,16 +60,16 @@ end
   describe json("/etc/sensu/assets/sensu-plugins-#{p}.json") do
     require 'uri'
     its(%w(type)) { should eq 'Asset' }
-    its(%w(spec metadata name)) { should eq "sensu-plugins-#{p}" }
-    its(%w(spec metadata namespace)) { should eq 'default' }
+    its(%w(metadata name)) { should eq "sensu-plugins-#{p}" }
+    its(%w(metadata namespace)) { should eq 'default' }
     its(%w(spec url)) { should match URI::DEFAULT_PARSER.make_regexp }
   end
 end
 
 describe json('/etc/sensu/handlers/slack.json') do
   its(%w(type)) { should eq 'Handler' }
-  its(%w(spec metadata name)) { should eq 'slack' }
-  its(%w(spec metadata namespace)) { should eq 'default' }
+  its(%w(metadata name)) { should eq 'slack' }
+  its(%w(metadata namespace)) { should eq 'default' }
   its(%w(spec command)) { should eq 'sensu-slack-handler --channel monitoring' }
   its(%w(spec env_vars)) { should include 'SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX' }
   its(%w(spec type)) { should eq 'pipe' }
@@ -78,20 +78,20 @@ end
 
 describe json('/etc/sensu/mutators/example-mutator.json') do
   its(%w(type)) { should eq 'Mutator' }
-  its(%w(spec metadata name)) { should eq 'example-mutator' }
-  its(%w(spec metadata namespace)) { should eq 'default' }
+  its(%w(metadata name)) { should eq 'example-mutator' }
+  its(%w(metadata namespace)) { should eq 'default' }
   its(%w(spec timeout)) { should eq 60 }
 end
 
 describe json('/etc/sensu/entitys/example-entity.json') do
   its(%w(type)) { should eq 'Entity' }
-  its(%w(spec metadata name)) { should eq 'example-entity' }
+  its(%w(metadata name)) { should eq 'example-entity' }
   its(%w(spec subscriptions)) { should include 'example-entity' }
   its(%w(spec entity_class)) { should eq 'proxy' }
-  its(%w(spec metadata namespace)) { should eq 'default' }
-  its(%w(spec metadata labels environment)) { should eq 'production' }
-  its(%w(spec metadata labels region)) { should eq 'us-west-2' }
-  its(%w(spec metadata annotations runbook)) { should eq 'https://www.xkcd.com/378/' }
+  its(%w(metadata namespace)) { should eq 'default' }
+  its(%w(metadata labels environment)) { should eq 'production' }
+  its(%w(metadata labels region)) { should eq 'us-west-2' }
+  its(%w(metadata annotations runbook)) { should eq 'https://www.xkcd.com/378/' }
 end
 
 describe json('/etc/sensu/namespaces/test-org.json') do
@@ -101,8 +101,8 @@ end
 
 describe json('/etc/sensu/hooks/restart_cron_service.json') do
   its(%w(type)) { should eq 'Hook' }
-  its(%w(spec metadata name)) { should eq 'restart_cron_service' }
-  its(%w(spec metadata namespace)) { should eq 'default' }
+  its(%w(metadata name)) { should eq 'restart_cron_service' }
+  its(%w(metadata namespace)) { should eq 'default' }
   its(%w(spec command)) { should eq 'sudo service cron restart' }
   its(%w(spec timeout)) { should eq 60 }
 end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### Purpose

Refactoring to DRY things up.

#### Known Compatibility Issues

This change probably breaks compatibility with Sensu Go pre-GA beta releases, but those aren't supported releases anyway.
