### PR TITLE
Use a guard and not .error? method for sensu_ctl

### DIFF
--- a/libraries/helpers_sensuctl.rb
+++ b/libraries/helpers_sensuctl.rb
@@ -18,6 +18,15 @@ module SensuCookbook
         opts
       end
 
+      def sensuctl_cluster_config
+        cluster_config = ::File.join(ENV['HOME'],'.config/sensu/sensuctl/cluster')
+        if ::File.exist?(cluster_config)
+          JSON.parse(IO.read(cluster_config))
+        else
+          {}
+        end
+      end
+
       def sensuctl_configure_cmd
         if node['platform'] != 'windows'
           [sensuctl_bin, 'configure', sensuctl_configure_opts].flatten

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -103,12 +103,12 @@ action :install do
 end
 
 action :configure do
-  if shell_out('sensuctl user list').error?
-    converge_by 'Reconfiguring sensuctl' do
-      execute 'configure sensuctl' do
-        command sensuctl_configure_cmd
-        sensitive true unless new_resource.debug
-      end
+  converge_by 'Reconfiguring sensuctl' do
+    config = sensuctl_cluster_config
+    execute 'configure sensuctl' do
+      command sensuctl_configure_cmd
+      sensitive true unless new_resource.debug
+      not_if { config['api-url'] == new_resource.backend_url }
     end
   end
 end


### PR DESCRIPTION
I don't remember the reason for trying to use .error? to check the
output of the shell exec. What matters though is that the configure is
run once when needed and not every time once it's already configured.

This change switches to using a guard and a method to compare the
configured backend url.

The shortcoming of this approach is that as resource is currently
written it supports a username and password property, however we do not
have an implementation that can safely handle reconfiguring these
values so they will only work the first time the resource is used.

Fixes #63

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [ ] Adedd documentation for it to the `README.md`

#### Purpose

#### Known Compatibility Issues