### PR TITLE
Run builds in travis on xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,43 @@
 sudo: required
-dist: trusty
+dist: xenial
 
-# install the pre-release chef-dk.  Use chef-stable-precise to install the stable release
+# Install the pre-release chef tools
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-current-xenial
     packages:
-      - chefdk
+      - chef-workstation
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
 
 branches:
   only:
-  - master
+    - master
 
 services: docker
 
 env:
   global:
-  - CHEF_LICENSE="accept-no-persist"
+    - CHEF_LICENSE="accept-no-persist"
   matrix:
-  - INSTANCE=default-centos-6
-  - INSTANCE=default-centos-7
-  - INSTANCE=default-ubuntu-1404
-  - INSTANCE=default-ubuntu-1604
-  - INSTANCE=default-ubuntu-1804
+    - INSTANCE=default-centos-6
+    - INSTANCE=default-centos-7
+    - INSTANCE=default-ubuntu-1404
+    - INSTANCE=default-ubuntu-1604
+    - INSTANCE=default-ubuntu-1804
 
 # Ensure we make ChefDK's Ruby the default
 before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef gem install kitchen-dokken
-  - /opt/chefdk/embedded/bin/chef --version
-  - /opt/chefdk/embedded/bin/cookstyle --version
-  - /opt/chefdk/embedded/bin/foodcritic --version
+  - eval "$(/opt/chef-workstation/bin/chef shell-init bash)"
+  - /opt/chef-workstation/bin/chef gem install kitchen-dokken
+  - /opt/chef-workstation/bin/chef gem install kitchen-dokken
+  - /opt/chef-workstation/bin/chef --version
+  - /opt/chef-workstation/bin/cookstyle --version
+  - /opt/chef-workstation/bin/foodcritic --version
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
 
@@ -47,9 +48,9 @@ after_script:
 
 matrix:
   include:
-  - script: /opt/chefdk/embedded/bin/cookstyle
-    env:  COOKSTYLE=1
-  - script: /opt/chefdk/embedded/bin/foodcritic . --exclude spec -f any -P
-    env:  FOODCRITIC=1
-  - script: /opt/chefdk/embedded/bin/rspec
-    env:  CHEFSPEC=1
+    - script: /opt/chef-workstation/bin/cookstyle
+      env: COOKSTYLE=1
+    - script: /opt/chef-workstation/bin/foodcritic . --exclude spec -f any -P
+      env: FOODCRITIC=1
+    - script: /opt/chef-workstation/embedded/bin/rspec
+      env: CHEFSPEC=1


### PR DESCRIPTION
Switching to xenial since it's a newer base and has support for the
addons needed to run chef integration testing.

bionic doesn't yet appear to be added to the approved list of resources
for the apt addon:

* https://github.com/travis-ci/apt-source-safelist/tree/master/keys

Additionally switched package from chefdk to chef-workstation to stay up
to date with what's maintained. Same tools, different name.

--

#### Purpose

Update the base platform used for travis builds.

#### Known Compatibility Issues

None