### PR TITLE
Fix: support filters on sensu_asset resource

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -64,6 +64,7 @@ module SensuCookbook
       spec = {}
       spec['sha512'] = new_resource.sha512
       spec['url'] = new_resource.url
+      spec['filters'] = new_resource.filters if new_resource.filters
 
       a = base_resource(new_resource, spec)
       a['metadata']['namespace'] = new_resource.namespace


### PR DESCRIPTION
The resource supported `filters` as a property but it was not supported
by the helper library that builds the object definition.

It's easy to miss this kind of thing when making enhancements, perhaps
this is another area to simplify.

fixes #54

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### Purpose

Bugfix

#### Known Compatibility Issues

None