### PR TITLE
adding a returns to the backend init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+- `sensu-backend` action :init adding returns to account for possible return codes.  exit code 3 is returned when already init.  This allows chef-client runs to not fail when running idempotently.
+
 ## [0.2.0] - 2020-01-05
 ### Breaking Changes
 

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -76,6 +76,7 @@ action :init do
   execute 'configure sensuctl' do
     command sensu_backend_init_cmd
     sensitive true unless new_resource.debug
+    returns [0, 3]
   end
 end
 


### PR DESCRIPTION
fixes #82

## Pull Request Checklist

fixes #82

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Foodcritic passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### Purpose
This allows the `sensu-backend init` to accept a return code of `3` as an acceptable return.  It is returned by the application when the backend is already init'd.  As Sensu Go does not have a status endpoint for the init, it is not possible to idempotently check, so they return `3` as the alternative.
