### PR TITLE
Added support for custom packages for Sensu's backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ## [Unreleased]
 
 - `sensu-backend` action :init adding returns to account for possible return codes.  exit code 3 is returned when already init.  This allows chef-client runs to not fail when running idempotently.
+- `sensu-backend` now supports specifying an apt or yum repository for packages built from source.
 
 ## [0.2.0] - 2020-01-05
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -134,15 +134,25 @@ The sensu backend resource can configure the core sensu backend service.
 
 #### Properties
 * `version` which version to install, default: *latest*
-* `repo` which repo to pull package from, default: *sensu/stable*
+* `repo` which repo to pull package from, default: *sensu/stable*. If using private yum or apt repository, this is the baseurl/uri.
 * `config_home` where to store the generated object definitions, default: */etc/sensu*
 * `config` a hash of configuration, default: *{ 'state-dir': '/var/lib/sensu/sensu-backend'}*
+* `distribution` possible values: commercial, source. Requires a valid yum or apt repository for installation. default: commercial
+* `gpgkey` To be used with a package built from source. The GPG key for the package.
 * `username` the username to initialize the backend with
 * `password` the password to initialize the backend with
 
 #### Examples
 ```rb
 sensu_backend 'default'
+```
+
+For using packages built from source:
+```
+sensu_backend 'default' do
+  distribution 'source'
+  repo 'https://my-custom-repo.com/yum/$releasever/$basearch/'
+end
 ```
 Optionally pass configuration values for the backend:
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Foodcritic passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Adedd documentation for it to the `README.md`

#### Purpose
Since this cookbook uses packagecloud to manage the repository for packages, it's currently impossible to install a non-commercial version of Sensu Go. This PR allows for specification of a yum or apt repository for Sensu Go packages built from source. By default, the commercial distribution is still the chosen.

#### Known Compatibility Issues
