### PR TITLE
Add namespace property to sensu_asset resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `sensu_asset` now supports namespaces that are not `default`. Default is the `default` namespace. (@joe-armstrong)
+
 ### Breaking Changes
 - `sensu_check` now does not provide defaults for `command` and `subscriptions`, and they must be required as per the upstream specs. (@kovukono)
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ At runtime the agent can sequentially fetch assets and store them in its local c
 * `filters` a set of filter criteria used by the agent to determine of the asset should be installed.
 * `sha512` **required** the checksum of the asset.
 * `url` **required** the URL location of the asset.
+* `namespace` the Sensu RBAC namespace that this check belongs to, default: *default*
 
 #### Examples
 ```rb

--- a/resources/asset.rb
+++ b/resources/asset.rb
@@ -32,6 +32,7 @@ provides :sensu_asset
 property :filters, Array
 property :sha512, String, required: true
 property :url, String, required: true
+property :namespace, String, default: 'default'
 
 action_class do
   include SensuCookbook::Helpers

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -40,6 +40,7 @@ assets.each do |name, property|
   sensu_asset name do
     url property['url']
     sha512 property['checksum']
+    namespace property['namespace']
   end
 end
 

--- a/test/integration/data_bags/sensu/assets.json
+++ b/test/integration/data_bags/sensu/assets.json
@@ -2,19 +2,23 @@
   "id":"assets",
   "sensu-plugins-http": {
     "url": "https://github.com/sensu-plugins/sensu-plugins-http/archive/2.9.0.tar.gz",
-    "checksum": "b57cacd2b479f41b5d002c037ac3005e7a655d1dfae93c457f0c19dde21fc992771b5d290a2cce9255578d9bd2fc88075646e3e0e02e3c01d8e1e274ae0b7376"
+    "checksum": "b57cacd2b479f41b5d002c037ac3005e7a655d1dfae93c457f0c19dde21fc992771b5d290a2cce9255578d9bd2fc88075646e3e0e02e3c01d8e1e274ae0b7376",
+    "namespace": "default"
   },
   "sensu-plugins-docker": {
     "url": "https://github.com/sensu-plugins/sensu-plugins-docker/archive/3.0.0.tar.gz",
-    "checksum": "96f71be5824ae50db8992ffdd1a94076170457cd9ca4f8563d739ffb07d65aca06c1d2ff5590b10f73089b300a74a3c5c255dcd9a4649487aa81a29e4f81c85c"
+    "checksum": "96f71be5824ae50db8992ffdd1a94076170457cd9ca4f8563d739ffb07d65aca06c1d2ff5590b10f73089b300a74a3c5c255dcd9a4649487aa81a29e4f81c85c",
+    "namespace": "default"
   },
   "sensu-plugins-postgres": {
     "url": "https://github.com/sensu-plugins/sensu-plugins-postgres/archive/1.4.6.tar.gz",
-    "checksum": "b4369e69f3e3247b6f48596733da2f1a3c66fceebb60e6b00c70f404324876696fc8d2381206c47bd9d09227b2d6d3802f359e2ae349d71930bd0d45c0b3d554"
+    "checksum": "b4369e69f3e3247b6f48596733da2f1a3c66fceebb60e6b00c70f404324876696fc8d2381206c47bd9d09227b2d6d3802f359e2ae349d71930bd0d45c0b3d554",
+    "namespace": "default"
   },
   "sensu-slack-handler": {
     "url": "https://github.com/sensu/sensu-slack-handler/releases/download/1.0.3/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
-    "checksum": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8"
+    "checksum": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8",
+    "namespace": "default"
   },
   "sensu-plugins-disk-checks": {
     "url": "https://github.com/sensu-plugins/sensu-plugins-disk-checks/archive/5.1.3.tar.gz",

--- a/test/integration/data_bags/sensu/assets.json
+++ b/test/integration/data_bags/sensu/assets.json
@@ -15,5 +15,10 @@
   "sensu-slack-handler": {
     "url": "https://github.com/sensu/sensu-slack-handler/releases/download/1.0.3/sensu-slack-handler_1.0.3_linux_amd64.tar.gz",
     "checksum": "68720865127fbc7c2fe16ca4d7bbf2a187a2df703f4b4acae1c93e8a66556e9079e1270521999b5871473e6c851f51b34097c54fdb8d18eedb7064df9019adc8"
+  },
+  "sensu-plugins-disk-checks": {
+    "url": "https://github.com/sensu-plugins/sensu-plugins-disk-checks/archive/5.1.3.tar.gz",
+    "checksum": "ac962813f1730b9eb6f10a3224948bcdaa8c2e4171a25cf929dc671b748d5535ad86cd5c0c7b6e0a89986c0c24cf867cbcbfa1766eb4923c69a05492da079495",
+    "namespace": "test-org"
   }
 }

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -66,6 +66,14 @@ end
   end
 end
 
+describe json("/etc/sensu/assets/sensu-plugins-disk-checks.json") do
+  require 'uri'
+  its(%w(type)) { should eq 'Asset' }
+  its(%w(metadata name)) { should eq "sensu-plugins-disk-checks" }
+  its(%w(metadata namespace)) { should eq 'test-org' }
+  its(%w(spec url)) { should match URI::DEFAULT_PARSER.make_regexp }
+end
+
 describe json('/etc/sensu/handlers/slack.json') do
   its(%w(type)) { should eq 'Handler' }
   its(%w(metadata name)) { should eq 'slack' }

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -66,10 +66,10 @@ end
   end
 end
 
-describe json("/etc/sensu/assets/sensu-plugins-disk-checks.json") do
+describe json('/etc/sensu/assets/sensu-plugins-disk-checks.json') do
   require 'uri'
   its(%w(type)) { should eq 'Asset' }
-  its(%w(metadata name)) { should eq "sensu-plugins-disk-checks" }
+  its(%w(metadata name)) { should eq 'sensu-plugins-disk-checks' }
   its(%w(metadata namespace)) { should eq 'test-org' }
   its(%w(spec url)) { should match URI::DEFAULT_PARSER.make_regexp }
 end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [x] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [x] Added documentation for it to the `README.md`

#### Purpose

The `sensu_asset` resource installs assets in the `default` namespace. This PR adds a `namespace` property to the `sensu_asset` resource that is not required and defaults to the `default` namespace. 
