### PR TITLE
windows agent and ctl update to 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Updated the attributes for `agent` and `ctl` to version `6.1.0`. (@derekgroh)
 
 ## [1.1.0] - 2020-09-27
 ### Added

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -1,4 +1,4 @@
 default['sensu-go']['sensu_bindir'] = 'c:/Program Files/sensu/sensu-agent/bin'
-default['sensu-go']['windows_msi_source'] = 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.11.1/sensu-go-agent_5.11.1.5015_en-US.x64.msi'
-default['sensu-go']['windows_msi_checksum'] = '776577450E7063FD78D937EA3C0AF6B93F20017499E692DD3FA6ED8BA0DC8835'
-default['sensu-go']['msi_version'] = '5.11.1'
+default['sensu-go']['windows_msi_source'] = 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.1.0/sensu-go-agent_6.1.0.3465_en-US.x64.msi'
+default['sensu-go']['windows_msi_checksum'] = 'EDDDBEC298837B69DCFD5A575B620CC7285A51C7F31801AE650FFD343837ACAB'
+default['sensu-go']['msi_version'] = '6.1.0'

--- a/attributes/ctl.rb
+++ b/attributes/ctl.rb
@@ -1,1 +1,1 @@
-default['sensu-go']['ctl_version'] = '5.11.1'
+default['sensu-go']['ctl_version'] = '6.1.0'

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -23,6 +23,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+require 'yaml'
+
 resource_name :sensu_agent
 provides :sensu_agent
 

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -68,20 +68,20 @@ action :install do
     directory 'c:\sensutemp'
 
     powershell_script 'Download Sensuctl' do
-      code "Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/#{node['sensu-go']['ctl_version']}/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz  -OutFile c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
-      not_if "Test-Path c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
+      code "Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/#{node['sensu-go']['ctl_version']}/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz  -OutFile c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
+      not_if "Test-Path c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
     end
 
     seven_zip_archive 'Extract Sensuctl Gz' do
-      path "c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar"
-      source "c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
+      path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar"
+      source "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
       overwrite true
       timeout   30
     end
 
     seven_zip_archive 'Extract Sensuctl Tar' do
-      path "c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64"
-      source "c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar"
+      path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64"
+      source "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar"
       overwrite true
       timeout   30
     end
@@ -91,7 +91,7 @@ action :install do
     end
 
     remote_file "#{sensuctl_bin}\\sensuctl.exe" do
-      source "file:///c:/sensutemp/sensu-enterprise-go_#{node['sensu-go']['ctl_version']}_windows_amd64/sensuctl.exe"
+      source "file:///c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64/sensuctl.exe"
     end
 
     windows_path sensuctl_bin

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -12,7 +12,7 @@ RSpec.shared_context 'common_stubs' do
     stubs_for_provider('sensu_ctl[default]') do |provider|
       allow(provider).to receive_shell_out('sensuctl user list')
     end
-    stub_command("Test-Path c:/sensutemp/sensu-enterprise-go_5.11.1_windows_amd64.tar.gz").and_return(true) # rubocop:disable Style/StringLiterals
+    stub_command("Test-Path c:/sensutemp/sensu-go_6.1.0_windows_amd64.tar.gz").and_return(true) # rubocop:disable Style/StringLiterals
   end
 end
 


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Foodcritic passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

N/A

#### Purpose

Updated windows agent and ctl version to 6.1.0 (October 5, 2020)
Corrects undefined_method error found while validating.

#### Known Compatibility Issues

Chef 15+ replaces `seven_zip` resource with `archive_file` which is detected by cookstyle and failes rspec tests related to this resource.
