### PR TITLE
Fix yaml rendering and travis ci for latest Chef 16.x

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,6 +1,7 @@
 driver:
   name: dokken
   chef_version: latest
+  chef_license: accept-no-persist
   privileged: true # because Docker and SystemD/Upstart
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup
@@ -17,6 +18,16 @@ verifier:
   sudo: false
 
 platforms:
+- name: amazonlinux
+  driver:
+    image: dokken/amazonlinux
+    pid_one_command: /sbin/init
+
+- name: amazonlinux-2
+  driver:
+    image: dokken/amazonlinux-2
+    pid_one_command: /usr/lib/systemd/systemd
+
 - name: centos-6
   driver:
     image: dokken/centos-6
@@ -29,18 +40,24 @@ platforms:
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: ubuntu-14.04
-  driver:
-    image: dokken/ubuntu-14.04
-    pid_one_command: /sbin/init
-
 - name: ubuntu-16.04
   driver:
     image: dokken/ubuntu-16.04
     pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
 
 - name: ubuntu-18.04
   driver:
     image: dokken/ubuntu-18.04
     pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: ubuntu-20.04
+  driver:
+    image: dokken/ubuntu-20.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
 # Use test suites defined in base .kitchen.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,16 +4,16 @@ driver:
 
 provisioner:
   name: chef_zero
-  client_rb:
-    chef_license: accept
+  deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: centos-6
   - name: centos-7
   - name: windows-2012r2
@@ -35,16 +35,20 @@ suites:
     run_list:
       - recipe[sensu_test::default]
       - recipe[sensu_test::postgres]
+      - recipe[sensu_test::ctl]
     driver:  
       network:
-        - ["private_network", {ip: "172.128.10.2"}]
+        - ["private_network", {ip: "172.128.10.2", autocorrect: true}]
     verifier:
       inspec_tests:
         - test/integration/default
         - test/integration/postgres
+        - test/integration/ctl
     attributes:
       username: admin
       password: password
+    driver:
+      network:
     excludes:
       - windows-2012r2
       - windows-2016
@@ -55,14 +59,4 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/agent
-    attributes:
-  - name: ctl
-    run_list:
-      - recipe[sensu_test::ctl]
-    driver:  
-      network:
-        - ["private_network", {ip: "172.128.10.3", autocorrect: true}]
-    verifier:
-      inspec_tests:
-        - test/integration/ctl
     attributes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,14 @@ env:
   global:
     - CHEF_LICENSE="accept-no-persist"
   matrix:
+    - INSTANCE=default-amazonlinux
+    - INSTANCE=default-amazonlinux-2
     - INSTANCE=default-centos-6
     - INSTANCE=default-centos-7
     - INSTANCE=default-ubuntu-1404
     - INSTANCE=default-ubuntu-1604
     - INSTANCE=default-ubuntu-1804
+    - INSTANCE=default-ubuntu-2004
 
 # Ensure we make ChefDK's Ruby the default
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
-sudo: required
-dist: xenial
+dist: bionic
 
-# Install the pre-release chef tools
-addons:
-  apt:
-    sources:
-      - chef-current-xenial
-    packages:
-      - chef-workstation
+before_install:
+  - curl -sL https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chef-workstation
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
@@ -26,7 +20,6 @@ env:
     - INSTANCE=default-amazonlinux-2
     - INSTANCE=default-centos-6
     - INSTANCE=default-centos-7
-    - INSTANCE=default-ubuntu-1404
     - INSTANCE=default-ubuntu-1604
     - INSTANCE=default-ubuntu-1804
     - INSTANCE=default-ubuntu-2004
@@ -36,10 +29,7 @@ before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chef-workstation/bin/chef shell-init bash)"
-  - /opt/chef-workstation/bin/chef gem install kitchen-dokken
-  - /opt/chef-workstation/bin/chef gem install kitchen-dokken
   - /opt/chef-workstation/bin/chef --version
-  - /opt/chef-workstation/bin/cookstyle --version
   - /opt/chef-workstation/bin/foodcritic --version
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Fix yaml rendering for agent and backend with Chef 16.x
 - Updated the attributes for `agent` and `ctl` to version `6.1.0`. (@derekgroh)
 
 ## [1.1.0] - 2020-09-27

--- a/README.md
+++ b/README.md
@@ -18,23 +18,26 @@ See the [sensu](https://supermarket.chef.io/cookbooks/sensu) cookbook if you wis
 
 ## Requirements
 
-* Chef 12.5 or higher.
+* Chef 15.0 or higher.
 * Network accessible package repositories.
 
 ## Platform Support
 The following platforms have been tested with Test Kitchen. It will most likely work on other platforms as well.
 
-| Platform | Supported Version|
-|---------------|-------|
-|               | 0.0.1 |
-| centos-6      | X     |
-| centos-7      | X     |
-| fedora        | X     |
-| ubuntu-14.04  | X     |
-| ubuntu-16.04  | X     |
-| windows-2012r2 | Agent Only |
-| windows-2016 | Agent Only |
-| windows-2019 | Agent Only |
+| Platform       | Supported Version |
+|----------------|-------------------|
+|                | 0.0.1             |
+| amazonlinux    | X                 |
+| amazonlinux-2  | X                 |
+| centos-6       | X                 |
+| centos-7       | X                 |
+| fedora         | X                 |
+| ubuntu-16.04   | X                 |
+| ubuntu-18.04   | X                 |
+| ubuntu-20.04   | X                 |
+| windows-2012r2 | Agent Only        |
+| windows-2016   | Agent Only        |
+| windows-2019   | Agent Only        |
 
 ## Cookbook Dependencies
 

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -23,8 +23,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-require 'yaml'
-
 resource_name :sensu_agent
 provides :sensu_agent
 
@@ -59,7 +57,7 @@ action :install do
 
     # render template at /etc/sensu/agent.yml for linux
     file ::File.join(new_resource.config_home, 'agent.yml') do
-      content(JSON.parse(new_resource.config.to_json).to_yaml.to_s)
+      content(YAML.dump(JSON.parse(new_resource.config.to_json)).to_s)
       notifies :restart, 'service[sensu-agent]', :delayed
     end
 

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -81,7 +81,7 @@ action :install do
 
   # render template at /etc/sensu/backend.yml
   file ::File.join(new_resource.config_home, 'backend.yml') do
-    content(JSON.parse(new_resource.config.to_json).to_yaml.to_s)
+    content(YAML.dump(JSON.parse(new_resource.config.to_json)).to_s)
   end
 
   service 'sensu-backend' do

--- a/spec/unit/recipes/sensu_agent_spec.rb
+++ b/spec/unit/recipes/sensu_agent_spec.rb
@@ -102,7 +102,7 @@ end
 
 RSpec.describe 'sensu_test::agent' do
   nix_platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
   win_platforms = {
@@ -186,7 +186,7 @@ end
 
 RSpec.describe 'sensu_test::remove_agent' do
   nix_platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
   win_platforms = {

--- a/spec/unit/recipes/sensu_backend_spec.rb
+++ b/spec/unit/recipes/sensu_backend_spec.rb
@@ -66,7 +66,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_check_spec.rb
+++ b/spec/unit/recipes/sensu_check_spec.rb
@@ -61,7 +61,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/recipes/sensu_cluster_role_binding_spec.rb
@@ -61,7 +61,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_cluster_role_spec.rb
+++ b/spec/unit/recipes/sensu_cluster_role_spec.rb
@@ -60,7 +60,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_ctl_spec.rb
+++ b/spec/unit/recipes/sensu_ctl_spec.rb
@@ -116,7 +116,7 @@ end
 
 RSpec.describe 'sensu_test::ctl' do
   nix_platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
   win_platforms = {

--- a/spec/unit/recipes/sensu_hook_spec.rb
+++ b/spec/unit/recipes/sensu_hook_spec.rb
@@ -61,7 +61,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_postgres_config_spec.rb
+++ b/spec/unit/recipes/sensu_postgres_config_spec.rb
@@ -62,7 +62,7 @@ end
 
 RSpec.describe 'sensu_test::postgres' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_role_binding_spec.rb
+++ b/spec/unit/recipes/sensu_role_binding_spec.rb
@@ -60,7 +60,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 

--- a/spec/unit/recipes/sensu_role_spec.rb
+++ b/spec/unit/recipes/sensu_role_spec.rb
@@ -61,7 +61,7 @@ end
 
 RSpec.describe 'sensu_test::default' do
   platforms = {
-    'ubuntu' => ['14.04', '16.04'],
+    'ubuntu' => ['16.04', '18.04', '20.04'],
     'centos' => '7.6',
   }
 


### PR DESCRIPTION
Upstream chef/chef introduced changes that broke default .to_yaml
behavior used in agent and backend resources.

As discussed in the related issues using `YAML.dump` will ensure the
library autoloads correctly. Switched to this method instead of using
`requires` for consistency.

fixes #104

refs:
* https://github.com/chef/chef/issues/10470
* https://github.com/chef/chef/issues/10492

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes. Fixes #104

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### Purpose

Fix issues with latest Chef 16.x releases

#### Known Compatibility Issues

None