### PR TITLE
Add header property for sensu_asset resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ## [Unreleased]
 - Fix yaml rendering for agent and backend with Chef 16.x
 - Updated the attributes for `agent` and `ctl` to version `6.1.0`. (@derekgroh)
+- Add `header` property support to `sensu_asset` resource. (@webframp)
 
 ## [1.1.0] - 2020-09-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -385,6 +385,8 @@ At runtime the agent can sequentially fetch assets and store them in its local c
 * `sha512` **required** the checksum of the asset.
 * `url` **required** the URL location of the asset.
 * `namespace` the Sensu RBAC namespace that this check belongs to, default: *default*
+* `builds` List, defines multiple artifacts that provide the named asset.
+* `headers` Optional HTTP headers to apply to dynamic runtime asset retrieval
 
 #### Examples
 ```rb

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -78,6 +78,7 @@ module SensuCookbook
       else
         spec['builds'] = new_resource.builds
       end
+      spec['headers'] = new_resource.headers if new_resource.headers
       a = base_resource(new_resource, spec)
       a['metadata']['namespace'] = new_resource.namespace
       a

--- a/resources/asset.rb
+++ b/resources/asset.rb
@@ -57,6 +57,7 @@ property :builds, Array, default: [], required: false, callbacks: {
   end,
 }
 property :namespace, String, default: 'default'
+property :headers, Hash, default: {}
 
 action_class do
   include SensuCookbook::Helpers

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -58,6 +58,7 @@ assets.each do |name, property|
     url property['url']
     sha512 property['checksum']
     namespace property['namespace']
+    headers property['headers'] if property['headers']
   end
 end
 

--- a/test/integration/data_bags/sensu/assets.json
+++ b/test/integration/data_bags/sensu/assets.json
@@ -3,7 +3,8 @@
   "sensu-plugins-http": {
     "url": "https://github.com/sensu-plugins/sensu-plugins-http/archive/2.9.0.tar.gz",
     "checksum": "b57cacd2b479f41b5d002c037ac3005e7a655d1dfae93c457f0c19dde21fc992771b5d290a2cce9255578d9bd2fc88075646e3e0e02e3c01d8e1e274ae0b7376",
-    "namespace": "default"
+    "namespace": "default",
+    "headers": { "X-Forwarded-For": "client1, proxy1, proxy2" }
   },
   "sensu-plugins-docker": {
     "url": "https://github.com/sensu-plugins/sensu-plugins-docker/archive/3.0.0.tar.gz",

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -82,6 +82,11 @@ end
   end
 end
 
+# http test data has optional header field defined
+describe json('/etc/sensu/assets/sensu-plugins-http.json') do
+  its(%w(spec headers X-Forwarded-For)) { should eq 'client1, proxy1, proxy2' }
+end
+
 describe json('/etc/sensu/assets/multi-build.json') do
   require 'uri'
   its(%w(type)) { should eq 'Asset' }


### PR DESCRIPTION
Sensu assets support option HTTP headers to apply to dynamic runtime
asset retrieval requests but the `sensu_asset` resource has lacked
support for this field.

This adds support for the property as a hash and updates test data to
apply to one asset

fixes #99

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Foodcritic passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [x] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [x] Added documentation for it to the `README.md`

#### Purpose

Add support for the optional HTTP headers supported with dynamic runtime asset retrieval

#### Known Compatibility Issues

None