### PR TITLE
Switch sensu_ctl resouce to use archive_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ### Fixed
 
 - Fixed outfile for sensuctl install for Windows, as well as preventing unnecessary downloads for install. Fixed configure action for Windows that was unable to parse array. (@kovukono)
+- Fixed `sensu_ctl` resource to only extract downloads on new versions, not every chef run (@webframp)
 
 ### Added
 
 - `sensu_auth_oidc` resource added (@webframp)
 - `sensu_auth_ldap` resource for ldap integration. (@webframp)
-- `sensu_auth_oidc` resource added (@webframp)
 - `sensu_etcd_replicator` resource for managing cluster RBAC federation (@webframp)
 - `sensu_search` resource added (@webframp)
 - `sensu_global_config` resource to manage web ui configuration (@webframp)
@@ -24,6 +24,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ### Changed
 
 - Rename `:ad_servers` property of `sensu_active_diretory` resource to `:auth_servers`. For consistency with `sensu_auth_ldap` resource this property was renamed and will be removed in a future cookbook version. (@webframp)
+- Refactored `sensu_ctl` to use builtin (Chef 15+) `archive_file` resource and remove 3rd party `seven_zip` cookbook dependency. (@webframp)
 
 ## [1.2.0] - 2020-10-17
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,4 +27,3 @@ issues_url 'https://github.com/sensu/sensu-go-chef/issues'
 source_url 'https://github.com/sensu/sensu-go-chef'
 
 depends 'packagecloud'
-depends 'seven_zip'

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -70,12 +70,14 @@ action :install do
       powershell_script 'Download Sensuctl' do
         code "Invoke-WebRequest https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/#{node['sensu-go']['ctl_version']}/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz  -OutFile c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
         not_if "Test-Path c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
+        notifies :extract, 'archive_file[Extract Sensuctl]'
       end
 
       archive_file 'Extract Sensuctl' do
         path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
         destination sensuctl_bin
         overwrite true
+        action :nothing
       end
 
       windows_path sensuctl_bin

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -63,7 +63,6 @@ action :install do
 
   if platform?('windows')
     # This is awaiting a packaged method to be delivered, but provides a resource currently.
-    include_recipe 'seven_zip'
 
     unless shell_out('sensuctl version').stdout.match?("sensuctl version #{node['sensu-go']['ctl_version']}")
       directory 'c:\sensutemp'
@@ -73,27 +72,11 @@ action :install do
         not_if "Test-Path c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
       end
 
-      seven_zip_archive 'Extract Sensuctl Gz' do
-        path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar"
-        source "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
-        overwrite true
-        timeout   30
-      end
-
-      seven_zip_archive 'Extract Sensuctl Tar' do
-        path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64"
-        source "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar"
-        overwrite true
-        timeout   30
-      end
-
-      directory sensuctl_bin do
-        recursive true
-      end
-
-      remote_file "#{sensuctl_bin}\\sensuctl.exe" do
-        source "file:///c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64/sensuctl.exe"
-      end
+    archive_file 'Extract Sensuctl' do
+      path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
+      destination sensuctl_bin
+      overwrite true
+    end
 
       windows_path sensuctl_bin
 

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -72,11 +72,11 @@ action :install do
         not_if "Test-Path c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
       end
 
-    archive_file 'Extract Sensuctl' do
-      path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
-      destination sensuctl_bin
-      overwrite true
-    end
+      archive_file 'Extract Sensuctl' do
+        path "c:/sensutemp/sensu-go_#{node['sensu-go']['ctl_version']}_windows_amd64.tar.gz"
+        destination sensuctl_bin
+        overwrite true
+      end
 
       windows_path sensuctl_bin
 

--- a/spec/unit/recipes/sensu_ctl_spec.rb
+++ b/spec/unit/recipes/sensu_ctl_spec.rb
@@ -76,20 +76,16 @@ RSpec.shared_examples 'sensu_ctl_win' do |platform, version|
       expect { chef_run }.to_not raise_error
     end
 
-    it 'includes the `seven_zip::default` recipe' do
-      expect(chef_run).to include_recipe('seven_zip::default')
-    end
-
     it 'creates a directory `c:\sensutemp`' do
       expect(chef_run).to create_directory('c:\sensutemp')
     end
 
     it 'extracts an archive' do
-      expect(chef_run).to extract_seven_zip_archive('Extract Sensuctl Gz')
+      expect(chef_run).to extract_archive_file('Extract Sensuctl Gz')
     end
 
     it 'extracts the archive' do
-      expect(chef_run).to extract_seven_zip_archive('Extract Sensuctl Tar')
+      expect(chef_run).to extract_archive_file('Extract Sensuctl Tar')
     end
 
     it 'creates a directory `c:\Program Files\Sensu\sensu-cli\bin\sensuctl`' do

--- a/spec/unit/recipes/sensu_ctl_spec.rb
+++ b/spec/unit/recipes/sensu_ctl_spec.rb
@@ -76,8 +76,13 @@ RSpec.shared_examples 'sensu_ctl_win' do |platform, version|
       expect { chef_run }.to_not raise_error
     end
 
-    it 'extracts an archive' do
-      expect(chef_run).to extract_archive_file('Extract Sensuctl')
+    it 'does nothing for an archive' do
+      expect(chef_run).to nothing_archive_file('Extract Sensuctl')
+    end
+
+    it 'notifies to extract the archive' do
+      ps_resource = chef_run.powershell_script('Download Sensuctl')
+      expect(ps_resource).to notify('archive_file[Extract Sensuctl]')
     end
 
     it 'adds `c:\Program Files\Sensu\sensu-cli\bin\sensuctl` to windows path' do

--- a/spec/unit/recipes/sensu_ctl_spec.rb
+++ b/spec/unit/recipes/sensu_ctl_spec.rb
@@ -76,24 +76,8 @@ RSpec.shared_examples 'sensu_ctl_win' do |platform, version|
       expect { chef_run }.to_not raise_error
     end
 
-    it 'creates a directory `c:\sensutemp`' do
-      expect(chef_run).to create_directory('c:\sensutemp')
-    end
-
     it 'extracts an archive' do
-      expect(chef_run).to extract_archive_file('Extract Sensuctl Gz')
-    end
-
-    it 'extracts the archive' do
-      expect(chef_run).to extract_archive_file('Extract Sensuctl Tar')
-    end
-
-    it 'creates a directory `c:\Program Files\Sensu\sensu-cli\bin\sensuctl`' do
-      expect(chef_run).to create_directory('c:\Program Files\Sensu\sensu-cli\bin\sensuctl')
-    end
-
-    it 'creates a remote_file `c:\Program Files\Sensu\sensu-cli\bin\sensuctl\sensuctl.exe`' do
-      expect(chef_run).to create_remote_file('c:\Program Files\Sensu\sensu-cli\bin\sensuctl\sensuctl.exe')
+      expect(chef_run).to extract_archive_file('Extract Sensuctl')
     end
 
     it 'adds `c:\Program Files\Sensu\sensu-cli\bin\sensuctl` to windows path' do


### PR DESCRIPTION
This removes the need for a dependency on the seven_zip cookbook since
archive_file is a builtin chef resources since Chef 15

fixes #110

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [ ] Added documentation for it to the `README.md`

#### Purpose

Modernize archive handling and remove dependency on seven_zip cookbook

#### Known Compatibility Issues

Unknown. Windows testing is not complete in CI, will need manual testing.