### PR TITLE
Add LDAP auth integration resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 ## [Unreleased]
 
+- `sensu_auth_ldap` resource for ldap integration. (@webframp)
 - `sensu_auth_oidc` resource added (@webframp)
 
 ## [1.2.0] - 2020-10-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 - `sensu_auth_ldap` resource for ldap integration. (@webframp)
 - `sensu_auth_oidc` resource added (@webframp)
+- Rename `:ad_servers` property of `sensu_active_diretory` resource to `:auth_servers`. For consistency with `sensu_auth_ldap` resource this property was renamed and will be removed in a future cookbook version. (@webframp)
 
 ## [1.2.0] - 2020-10-17
 

--- a/README.md
+++ b/README.md
@@ -652,14 +652,17 @@ end
 ```
 
 ### sensu_auth_ldap
+
 An ldap configuration to be applied to Sensu Go (commercial feature).
 
 #### Properties
+
 * `groups_prefix` Prefix for groups to include.
 * `username_prefix` Prefix for users to include.
 * `servers` **required** An array of ldap servers to connect to, including all of their properties as hashes. See [LDAP authentication](https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#lightweight-directory-access-protocol-ldap-authentication)
 
 #### Examples
+
 ```rb
 sensu_auth_ldap 'openldap' do
   servers [{

--- a/README.md
+++ b/README.md
@@ -651,6 +651,34 @@ sensu_auth_oidc 'fake_okta' do
 end
 ```
 
+### sensu_auth_ldap
+An ldap configuration to be applied to Sensu Go (commercial feature).
+
+#### Properties
+* `groups_prefix` Prefix for groups to include.
+* `username_prefix` Prefix for users to include.
+* `servers` **required** An array of ldap servers to connect to, including all of their properties as hashes. See [LDAP authentication](https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#lightweight-directory-access-protocol-ldap-authentication)
+
+#### Examples
+```rb
+sensu_auth_ldap 'openldap' do
+  servers [{
+    'host': '127.0.0.1',
+    'group_search': {
+      'base_dn': 'dc=acme,dc=org',
+      'attribute': 'member'
+      'object_class': 'groupOfNames'
+    },
+    'user_search': {
+      'base_dn': 'dc=acme,dc=org',
+      'attribute': 'uid',
+      'name_attribute': 'cn',
+      'object_class': 'person'
+    },
+  }]
+end
+```
+
 ### sensu_secret
 
 Create a secret that Sensu can grab from a secret provider so that sensitive information is not exposed (commercial feature).

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  deprecations_as_errors: true
+  deprecations_as_errors: false
   chef_license: accept-no-persist
 
 verifier:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -214,11 +214,15 @@ module SensuCookbook
 
     def active_directory_from_resource
       spec = {}
-      spec['servers'] = new_resource.ad_servers
+      spec['servers'] = new_resource.auth_servers
       spec['groups_prefix'] = new_resource.groups_prefix if new_resource.groups_prefix
       spec['username_prefix'] = new_resource.username_prefix if new_resource.groups_prefix
       base_resource(new_resource, spec, 'authentication/v2')
     end
+
+    # Spec for this is nearly identical to AD config spec but with a different type
+    # https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#ldap-configuration-examples
+    alias_method :auth_ldap_from_resource, :active_directory_from_resource
 
     def auth_oidc_from_resource
       spec = {}

--- a/resources/active_directory.rb
+++ b/resources/active_directory.rb
@@ -37,9 +37,10 @@ property :auth_servers, Array, required: true
 property :groups_prefix, String
 property :username_prefix, String
 property :resource_type, String, default: 'ad'
-# maintain backward compat with released cookbook versions for now
-alias_method :ad_servers, :auth_servers
 alias_method :servers, :auth_servers
+
+# maintain backward compat with released cookbook versions for now, but warn users
+deprecated_property_alias 'ad_servers', 'servers', 'ad_servers property was renamed to servers in v1.3.0 release of this cookbook. Please update recipes to use the new property name.'
 
 action :create do
   directory object_dir(false) do

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -310,6 +310,30 @@ sensu_auth_oidc 'fake_okta' do
   server 'https://oidc.example.com:9031'
 end
 
+sensu_auth_ldap 'example-auth-ldap' do
+  auth_servers [{
+    'host': '127.0.0.1',
+    'group_search': {
+      'base_dn': 'dc=acme,dc=org',
+    },
+    'user_search': {
+      'base_dn': 'dc=acme,dc=org',
+    },
+  }]
+end
+
+sensu_auth_ldap 'example-auth-ldap-alias' do
+  servers [{
+    'host': '127.0.0.1',
+    'group_search': {
+      'base_dn': 'dc=acme,dc=org',
+    },
+    'user_search': {
+      'base_dn': 'dc=acme,dc=org',
+    },
+  }]
+end
+
 sensu_secrets_provider 'vault' do
   provider_type 'VaultProvider'
   address 'https://vaultserver.example.com:8200'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -234,6 +234,14 @@ describe json('/etc/sensu/auth_oidc/fake_okta.json') do
   its(%w(spec username_claim)) { should eq 'email' }
 end
 
+%w(example-auth-ldap example-auth-ldap-alias).each do |ldap_name|
+  describe json("/etc/sensu/auth_ldap/#{ldap_name}.json") do
+    its(%w(type)) { should eq 'ldap' }
+    its(%w(api_version)) { should eq 'authentication/v2' }
+    its(%w(metadata name)) { should eq ldap_name }
+  end
+end
+
 describe json('/etc/sensu/secrets_providers/vault.json') do
   its(%w(type)) { should eq 'VaultProvider' }
   its(%w(metadata name)) { should eq 'vault' }


### PR DESCRIPTION
This is essentially the same behavior as #91 that added Active Directory
integration. LDAP auth has a different object type but this attempts to
reuse the same method as much as possible

It seems logical to refactor the AD resource to follow a naming
convention such as `sensu_auth_*`, since multiple external auth provider
types are supported by sensu. However, I purposefully limited the
changes made the the `active_directory` resources in this change and did
not rename them.

Note the ldap server property callback here is the same as that used in
the `sensu_asset` resource

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #81

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Add support for configuration of an external LDAP auth provider

#### Known Compatibility Issues

None