### PR TITLE
Add OIDC auth integration resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format located [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- `sensu_auth_oidc` resource added (@webframp)
 
 ## [1.2.0] - 2020-10-17
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -553,6 +553,33 @@ sensu_active_directory 'active_directory' do
 end
 ```
 
+### sensu_auth_oidc
+An OIDC  configuration applied to Sensu Go (commercial feature). Configuring OIDC is beyond the scope of this document, consult the sensu documentation for [OpenID Connect authentication](https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#openid-connect-10-protocol-oidc-authentication) and for [Registering an OIDC application](https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#register-an-oidc-application)
+
+* `additional_scopes` Scopes to include in the claims, in addition to the default `openid` scope.
+* `client_id` **required**
+* `client_secret` **required** The OIDC provider Client Secret. This value should be dynamically retrieved from a secret store such as chef-vault
+* `disable_offline_access`
+* `redirect_uri`
+* `server` **required** The location of the OIDC server you wish to authenticate against.
+* `groups_claim`
+* `groups_prefix`
+* `username_prefix`
+* `username_claim`
+* `resource_type`
+
+#### Examples
+``` rb
+sensu_auth_oidc 'fake_okta' do
+  additional_scopes ["groups", "email"]
+  client_id "a8e43af034e7f2608780"
+  # Demo only! The client secret value should come from somewhere like chef-vault
+  client_secret "b63968394be6ed2edb61c93847ee792f31bf6216"
+  redirect_uri "http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback"
+  server "https://oidc.example.com:9031"
+end
+```
+
 ### sensu_secret
 Create a secret that Sensu can grab from a secret provider so that sensitive information is not exposed (commercial feature).
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -220,6 +220,21 @@ module SensuCookbook
       base_resource(new_resource, spec, 'authentication/v2')
     end
 
+    def auth_oidc_from_resource
+      spec = {}
+      spec['additional_scopes'] = new_resource.additional_scopes if new_resource.additional_scopes
+      spec['client_id'] = new_resource.client_id
+      spec['client_secret'] = new_resource.client_secret
+      spec['disable_offline_access'] = new_resource.disable_offline_access
+      spec['redirect_uri'] = new_resource.redirect_uri if new_resource.redirect_uri
+      spec['server'] = new_resource.server
+      spec['groups_claim'] = new_resource.groups_claim
+      spec['groups_prefix'] = new_resource.groups_prefix if new_resource.groups_prefix
+      spec['username_claim'] = new_resource.username_claim
+      spec['username_prefix'] = new_resource.username_prefix if new_resource.username_prefix
+      base_resource(new_resource, spec, 'authentication/v2')
+    end
+
     def secret_from_resource
       spec = {}
       spec['id'] = new_resource.id

--- a/resources/auth_oidc.rb
+++ b/resources/auth_oidc.rb
@@ -1,0 +1,62 @@
+#
+# Cookbook:: sensu-go
+# Resource:: auth_oidc
+#
+# Copyright:: 2020 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+include SensuCookbook::SensuMetadataProperties
+include SensuCookbook::SensuCommonProperties
+
+resource_name :sensu_auth_oidc
+provides :sensu_auth_oidc
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+property :additional_scopes, Array
+property :client_id, String, required: true
+property :client_secret, String, required: true, sensitive: true
+property :disable_offline_access, [true, false], default: false
+property :redirect_uri, String
+property :server, String, required: true
+property :groups_claim, String, default: 'groups'
+property :groups_prefix, String
+property :username_prefix, String
+property :username_claim, String, default: 'email'
+property :resource_type, String, default: 'oidc'
+
+action :create do
+  directory object_dir(false) do
+    action :create
+    recursive true
+  end
+
+  file object_file(false) do
+    content JSON.generate(auth_oidc_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file(false)}]"
+  end
+
+  execute "sensuctl create -f #{object_file(false)}" do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -301,6 +301,15 @@ sensu_active_directory 'example-active-directory-alias' do
   }]
 end
 
+sensu_auth_oidc 'fake_okta' do
+  additional_scopes %w(groups email)
+  client_id 'a8e43af034e7f2608780'
+  # Demo only! The client secret value should come from somewhere like chef-vault
+  client_secret 'b63968394be6ed2edb61c93847ee792f31bf6216'
+  redirect_uri 'http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback'
+  server 'https://oidc.example.com:9031'
+end
+
 sensu_secrets_provider 'vault' do
   provider_type 'VaultProvider'
   address 'https://vaultserver.example.com:8200'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -220,6 +220,20 @@ end
   end
 end
 
+describe json('/etc/sensu/auth_oidc/fake_okta.json') do
+  its(%w(type)) { should eq 'oidc' }
+  its(%w(metadata name)) { should eq 'fake_okta' }
+  its(%w(api_version)) { should eq 'authentication/v2' }
+  its(%w(spec client_id)) { should eq 'a8e43af034e7f2608780' }
+  its(%w(spec client_secret)) { should eq 'b63968394be6ed2edb61c93847ee792f31bf6216' }
+  its(%w(spec additional_scopes)) { should include 'groups' }
+  its(%w(spec disable_offline_access)) { should eq false }
+  its(%w(spec redirect_uri)) { should eq 'http://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback' }
+  its(%w(spec server)) { should eq 'https://oidc.example.com:9031' }
+  its(%w(spec groups_claim)) { should eq 'groups' }
+  its(%w(spec username_claim)) { should eq 'email' }
+end
+
 describe json('/etc/sensu/secrets_providers/vault.json') do
   its(%w(type)) { should eq 'VaultProvider' }
   its(%w(metadata name)) { should eq 'vault' }


### PR DESCRIPTION
This adds a resource for configuring OIDC for authentication.

The OIDC [spec
attributes](https://docs.sensu.io/sensu-go/latest/operations/control-access/auth/#oidc-spec-attributes)
are sufficiently different from Active Directory or LDAP methods that it
is a different implementation but still following similar patterns to
other resources in this cookbook.

This biggest challenge I see for users is the handling of the OIDC app
registration "client secret" value. Users should however already have
some method of handling sensitive values, such as chef-vault, Hashicorp
vault or some other method that is expected to be compatible with their
chef usage to provide a dynamic configuration value of chef-client
runtime secrets.

For this reason I have noted in the example code that it is _not_
recommended to hard code secret values in resource usage.

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #81

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Allow configuraiton of OIDC authentication provider with a custom chef resource

#### Known Compatibility Issues

None