### PR TITLE
Add etcd_replicator resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ## [Unreleased]
 
 - `sensu_auth_oidc` resource added (@webframp)
+- `sensu_etcd_replicator` resource for managing cluster RBAC federation (@webframp)
 
 ## [1.2.0] - 2020-10-17
 

--- a/README.md
+++ b/README.md
@@ -732,9 +732,11 @@ end
 ```
 
 ### sensu_etcd_replicator
+
 Etcd replicators allow you to manage RBAC resources in one place and mirror the changes to follower clusters. This resource allows you to set up etcd mirrors for one-way key replication (commercial feature).
 
 #### Properties
+
 * `ca_cert` Path to an the PEM-format CA certificate to use for TLS client authentication. *Required if using default transport security*
 * `cert` Path to the PEM-format certificate to use for TLS client authentication. *Required if using default transport security*
 * `key` Path to the PEM-format key file associated with the cert to use for TLS client authentication. *Required if using default transport security*

--- a/README.md
+++ b/README.md
@@ -731,6 +731,44 @@ sensu_secrets_provider 'vault' do
 end
 ```
 
+### sensu_etcd_replicator
+Etcd replicators allow you to manage RBAC resources in one place and mirror the changes to follower clusters. This resource allows you to set up etcd mirrors for one-way key replication (commercial feature).
+
+#### Properties
+* `ca_cert` Path to an the PEM-format CA certificate to use for TLS client authentication. *Required if using default transport security*
+* `cert` Path to the PEM-format certificate to use for TLS client authentication. *Required if using default transport security*
+* `key` Path to the PEM-format key file associated with the cert to use for TLS client authentication. *Required if using default transport security*
+* `insecure` Set to true to disable transport security. *Not Recommended*. Default: `false`
+* `url` Destination cluster URL. Use comma separated list in single quotes for more than one.
+* `api_version` API version of the resource to replicate.
+* `resource` Name of the resource to replicate.
+* `namespace` Namespace to replicate or all namespaces for a given resource type if not set.
+* `replication_interval_seconds` Interval in seconds for replication.
+
+#### Examples
+
+``` rb
+sensu_etcd_replicator 'insecure_role_replicator' do
+  insecure true # NOTE: Disable transport security with care.
+  url 'http://127.0.0.1:2379'
+  resource 'Role'
+end
+
+sensu_etcd_replicator 'role_replicator' do
+  cert '/etc/ssl/fake.pem'
+  key '/etc/ssl/fake.key'
+  url 'http://127.0.0.1:2379'
+  resource 'Role'
+end
+
+sensu_etcd_replicator 'role_binding_replicator' do
+  cert '/etc/ssl/fake.pem'
+  key '/etc/ssl/fake.key'
+  url 'http://127.0.0.1:2379'
+  resource 'RoleBinding'
+end
+```
+
 ## License & Authors
 
 If you would like to see the detailed LICENSE click [here](./LICENSE).

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -256,6 +256,25 @@ module SensuCookbook
       base_resource(new_resource, spec, 'secrets/v1')
     end
 
+    def etcd_replicator_from_resource
+      spec = {}
+      unless new_resource.insecure
+        # Only required if insecure: false, meaning disabled transport security
+        spec['ca_cert'] = new_resource.ca_cert
+        spec['cert'] = new_resource.cert
+        spec['key'] = new_resource.cert
+      end
+      spec['insecure'] = new_resource.insecure
+      spec['url'] = new_resource.url
+      spec['api_version'] = new_resource.api_version
+      spec['resource'] = new_resource.resource
+      spec['namespace'] = new_resource.namespace if new_resource.namespace
+      spec['replication_interval_seconds'] = new_resource.replication_interval_seconds
+      replicator = base_resource(new_resource, spec, 'federation/v1')
+      replicator['metadata']['created_by'] = 'chef-client'
+      replicator
+    end
+
     def latest_version?(version)
       version == 'latest' || version == :latest
     end

--- a/resources/etcd_replicator.rb
+++ b/resources/etcd_replicator.rb
@@ -37,11 +37,12 @@ action_class do
   end
 
   def check_resource_semantics!
-    error_msg = "\n\nFor the resource: #{new_resource.name} the property 'insecure' is set to 'false'.\n"\
-               "This is the default and enables transport security for replication.\n"\
-               "Transport security requires both 'cert' and 'key' properties of"\
-               'this resource to be set to valid local paths.'\
-               "Please set these values.\n\n"
+    error_msg = <<-EOH
+\n\nFor the resource: #{new_resource.name} the property 'insecure' is set to 'false'.
+This is the default and enables transport security for replication.
+Transport security requires both 'cert' and 'key' properties of this resource to be set to valid local paths.
+Please set these values.
+EOH
 
     if missing_secure_transport_property(new_resource.cert)
       raise error_msg

--- a/resources/etcd_replicator.rb
+++ b/resources/etcd_replicator.rb
@@ -1,0 +1,88 @@
+#
+# Cookbook:: sensu-go
+# Resource:: etcd_replicator
+#
+# Copyright:: 2020 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+include SensuCookbook::SensuMetadataProperties
+include SensuCookbook::SensuCommonProperties
+
+resource_name :sensu_etcd_replicator
+provides :sensu_etcd_replicator
+
+action_class do
+  include SensuCookbook::Helpers
+
+  def missing_secure_transport_property(name)
+    !new_resource.insecure && name.nil?
+  end
+
+  def check_resource_semantics!
+    error_msg = "\n\nFor the resource: #{new_resource.name} the property 'insecure' is set to 'false'.\n"\
+               "This is the default and enables transport security for replication.\n"\
+               "Transport security requires both 'cert' and 'key' properties of"\
+               'this resource to be set to valid local paths.'\
+               "Please set these values.\n\n"
+
+    if missing_secure_transport_property(new_resource.cert)
+      raise error_msg
+    end
+
+    if missing_secure_transport_property(new_resource.key)
+      raise error_msg
+    end
+  end
+end
+
+# Set sane platform property default so users generally should not need it
+default_ca_cert = value_for_platform_family(
+  %w(rhel fedora amazon) => '/etc/ssl/certs/ca-bundle.crt',
+  'debian' => '/etc/ssl/certs/ca-certificates.crt'
+)
+
+# Properties correspond to upstream spec attributes
+# https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/etcdreplicators/#spec-attributes
+property :ca_cert, String, default: default_ca_cert
+property :cert, String
+property :key, String
+property :insecure, [true, false], default: false
+property :url, String, required: true
+property :api_version, String, default: 'core/v2'
+property :resource, String, required: true
+property :namespace, String
+property :replication_interval_seconds, Integer, default: 30
+
+action :create do
+  directory object_dir(false) do
+    action :create
+    recursive true
+  end
+
+  file object_file(false) do
+    content JSON.generate(etcd_replicator_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file(false)}]"
+  end
+
+  execute "sensuctl create -f #{object_file(false)}" do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -340,3 +340,37 @@ sensu_secret 'env-secret-default' do
   id 'CONSUL_TOKEN'
   secrets_provider 'env'
 end
+
+sensu_etcd_replicator 'insecure_role_replicator' do
+  insecure true
+  url 'http://127.0.0.1:2379'
+  resource 'Role'
+end
+
+sensu_etcd_replicator 'role_replicator' do
+  cert '/etc/ssl/fake.pem'
+  key '/etc/ssl/fake.key'
+  url 'http://127.0.0.1:2379'
+  resource 'Role'
+end
+
+sensu_etcd_replicator 'role_binding_replicator' do
+  cert '/etc/ssl/fake.pem'
+  key '/etc/ssl/fake.key'
+  url 'http://127.0.0.1:2379'
+  resource 'RoleBinding'
+end
+
+sensu_etcd_replicator 'cluster_role_replicator' do
+  cert '/etc/ssl/fake.pem'
+  key '/etc/ssl/fake.key'
+  url 'http://127.0.0.1:2379'
+  resource 'ClusterRole'
+end
+
+sensu_etcd_replicator 'cluster_role_binding_replicator' do
+  cert '/etc/ssl/fake.pem'
+  key '/etc/ssl/fake.key'
+  url 'http://127.0.0.1:2379'
+  resource 'ClusterRoleBinding'
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -268,3 +268,30 @@ describe json('/etc/sensu/secrets/env-secret-default.json') do
   its(%w(spec id)) { should eq 'CONSUL_TOKEN' }
   its(%w(spec provider)) { should eq 'env' }
 end
+
+%w(cluster_role_binding_replicator
+  cluster_role_replicator
+  insecure_role_replicator
+  role_binding_replicator
+  role_replicator).each do |replicator|
+  describe json("/etc/sensu/etcd_replicator/#{replicator}.json") do
+    its(%w(type)) { should eq 'EtcdReplicator' }
+    its(%w(api_version)) { should eq 'federation/v1' }
+    its(%w(metadata created_by)) { should eq 'chef-client' }
+    its(%w(spec url)) { should eq 'http://127.0.0.1:2379' }
+    its(%w(spec resource)) { should be_in 'Role RoleBinding ClusterRole ClusterRoleBinding' }
+  end
+end
+
+%w(cluster_role_binding_replicator
+  cluster_role_replicator
+  role_binding_replicator
+  role_replicator).each do |replicator|
+  describe json("/etc/sensu/etcd_replicator/#{replicator}.json") do
+    its(%w(spec insecure)) { should eq false }
+  end
+end
+
+describe json('/etc/sensu/etcd_replicator/insecure_role_replicator.json') do
+  its(%w(spec insecure)) { should eq true }
+end


### PR DESCRIPTION
Etcd replication is a newer commercial feature of sensu-go, this adds a
custom resource to create the supported replicator resources.

There are some unique issues to handle with replication config that make
this resource a little more complex than others. It is technically
allowed to disable transport security by setting "insecure: true" on the
object definition in Sensu.

When using an insecure transport, the `ca_cert`,`cert` and `key` values
are not required in the spec.

There is no simple way to have Chef custom resource properties be
conditionally required properties based on the values of other
properties in the same resource. For this reason the
`check_resource_semantics!` callback is used for this custom resource to
validate the runtime usage of the transport security resource
properties.

If a user attempts to use this resource with the default value of
"insecure: false" (which will enable transport security for etcd
replication) a runtime error will be raised if they do not also set
the `cert` and `key` properties on the resource. The `ca_cert` property
has reasonable platform defaults but can be overidden.

Key management of the actual pem and key files is left entirely to the
user.

This error will look something like this:

```
[2020-10-19T01:03:17+00:00] FATAL: RuntimeError: sensu_etcd_replicator[cluster_role_binding_replicator] (sensu_test::default line 362) had an error: RuntimeError:

For the resource: cluster_role_binding_replicator the property 'insecure' is set to 'false'.
This is the default and enables transport security for replication.
Transport security requires both 'cert' and 'key' properties of this resource to be set to valid local paths. Please set these values.
```


----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #105

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [ ] Foodcritic passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Support management of etcd replication with chef resources

#### Known Compatibility Issues

None