### PR TITLE
Add resource for saved search management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - `sensu_auth_ldap` resource for ldap integration. (@webframp)
 - `sensu_auth_oidc` resource added (@webframp)
 - `sensu_etcd_replicator` resource for managing cluster RBAC federation (@webframp)
+- `sensu_search` resource added (@webframp)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -802,6 +802,29 @@ sensu_etcd_replicator 'role_binding_replicator' do
 end
 ```
 
+### sensu_search
+
+Create a save search that can be used in the Sensu web interface (commercial feature).
+
+#### Properties
+
+* `namespace` namespace for the save search
+* `parameters` **required** parameters the search will apply
+* `resource`  **required** fully qualified name of the resource
+
+#### Examples
+
+``` rb
+sensu_search 'check-config' do
+  parameters [
+      "published:true",
+      "subscription:linux",
+      "labelSelector: region == \"us-west-1\""
+  ]
+  resource 'core.v2/CheckConfig'
+end
+```
+
 ## License & Authors
 
 If you would like to see the detailed LICENSE click [here](./LICENSE).

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -279,6 +279,15 @@ module SensuCookbook
       replicator
     end
 
+    def search_from_resource
+      spec = {}
+      spec['parameters'] = new_resource.parameters
+      spec['resource'] = new_resource.resource
+      search = base_resource(new_resource, spec, 'searches/v1')
+      search['metadata']['namespace'] = new_resource.namespace
+      search
+    end
+
     def latest_version?(version)
       version == 'latest' || version == :latest
     end

--- a/resources/search.rb
+++ b/resources/search.rb
@@ -1,0 +1,73 @@
+#
+# Cookbook:: sensu-go
+# Resource:: search
+#
+# Copyright:: 2020 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+include SensuCookbook::SensuMetadataProperties
+include SensuCookbook::SensuCommonProperties
+
+resource_name :sensu_search
+provides :sensu_search
+
+property :namespace, String, default: 'default'
+property :parameters, Array, required: true, callbacks: {
+  'List can only contain valid sensu search parameters' => lambda do |arry|
+    arry.all? do |e|
+      e.start_with?('action', 'check', 'class',
+                    'entity', 'event', 'label', 'published',
+                    'silenced', 'status', 'subscription', 'type')
+    end
+  end,
+         }
+property :resource, String, required: true
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+action :create do
+  directory object_dir(plural = false) do
+    action :create
+    recursive true
+  end
+
+  file object_file(plural = false) do
+    content JSON.generate(search_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file(plural = false)}]"
+  end
+
+  execute "sensuctl create -f #{object_file(plural = false)}" do
+    action :nothing
+  end
+end
+
+action :delete do
+  execute "sensuctl delete -f #{object_file(plural = false)}" do
+    action :run
+    notifies :delete, "file[#{object_file(plural = false)}]"
+  end
+
+  file object_file(plural = false) do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -398,3 +398,12 @@ sensu_etcd_replicator 'cluster_role_binding_replicator' do
   url 'http://127.0.0.1:2379'
   resource 'ClusterRoleBinding'
 end
+
+sensu_search 'check-config' do
+  parameters [
+      'published:true',
+      'subscription:linux',
+      'labelSelector: region == \"us-west-1\"',
+  ]
+  resource 'core.v2/CheckConfig'
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -303,3 +303,10 @@ end
 describe json('/etc/sensu/etcd_replicator/insecure_role_replicator.json') do
   its(%w(spec insecure)) { should eq true }
 end
+
+describe json('/etc/sensu/search/check-config.json') do
+  its(%w(type)) { should eq 'Search' }
+  its(%w(metadata name)) { should eq 'check-config' }
+  its(%w(metadata namespace)) { should eq 'default' }
+  its(%w(spec resource)) { should eq 'core.v2/CheckConfig' }
+end


### PR DESCRIPTION
This resource adds basic support for creating search definitions

Searches are a commercial feature
* https://docs.sensu.io/sensu-go/latest/web-ui/searches-reference/

Update docs for search resource change

Note in changelog and readme with examples


----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #105

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Add `sensu_search` resource to manage save searches

#### Known Compatibility Issues

None