### PR TITLE
Add sensu_global_config resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - `sensu_auth_oidc` resource added (@webframp)
 - `sensu_etcd_replicator` resource for managing cluster RBAC federation (@webframp)
 - `sensu_search` resource added (@webframp)
+- `sensu_global_config` resource to manage web ui configuration (@webframp)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -825,6 +825,33 @@ sensu_search 'check-config' do
 end
 ```
 
+### sensu_global_config
+
+Web UI configuration allows you to define certain display options for the Sensu web UI, such as which web UI theme to use, the number of items to list on each page, and which URLs and linked images to expand. You can define a single custom web UI configuration to federate to all, some, or only one of your clusters (commercial feature).
+
+#### Properties
+
+* `always_show_local_cluster` Display the current cluster in federated environments
+* `default_preferences` Global defaults for page size and theme
+* `link_policy` Policy for what domains are valid and invalid targets
+
+#### Examples
+
+``` rb
+sensu_global_config 'custom-web-ui' do
+  default_preferences(page_size: 50,
+                      theme: "deuteranopia")
+  link_policy(allow_list: true,
+              urls: [
+                "https://example.com",
+                "steamapp://34234234",
+                "//google.com",
+                "//*.google.com",
+                "//bob.local"
+              ])
+end
+```
+
 ## License & Authors
 
 If you would like to see the detailed LICENSE click [here](./LICENSE).

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -288,6 +288,16 @@ module SensuCookbook
       search
     end
 
+    def global_config_from_resource
+      spec = {}
+      spec['always_show_local_cluster'] = new_resource.always_show_local_cluster
+      spec['default_preferences'] = new_resource.default_preferences
+      spec['link_policy'] = new_resource.link_policy
+      config = base_resource(new_resource, spec, 'web/v1')
+      config['metadata']['created_by'] = 'chef-client'
+      config
+    end
+
     def latest_version?(version)
       version == 'latest' || version == :latest
     end

--- a/resources/global_config.rb
+++ b/resources/global_config.rb
@@ -1,0 +1,77 @@
+#
+# Cookbook:: sensu-go
+# Resource:: global_config
+#
+# Copyright:: 2020 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+include SensuCookbook::SensuMetadataProperties
+include SensuCookbook::SensuCommonProperties
+
+resource_name :sensu_global_config
+provides :sensu_global_config
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+property :always_show_local_cluster, [true, false], default: false
+
+# https://docs.sensu.io/sensu-go/latest/web-ui/webconfig-reference/#default-preferences-attributes
+property :default_preferences, Hash, callbacks: {
+  'Should contain only valid default preference attributes' => lambda do |defaults|
+    defaults.keys do |pref|
+      [:page_size, :theme].include?(pref)
+    end && defaults.keys.length <= 2 # Only 2 valid preference attributes right now
+  end,
+  'Theme setting must be an allowed value' => lambda do |defaults|
+    %w(sensu classic uchiwa tritanopia deuteranopia).include?(defaults[:theme])
+  end,
+         }
+property :link_policy, Hash, callbacks: {
+  'Should be a valid link policy attribute' => lambda do |link|
+    link.keys do |pref|
+      [:allow_list, :urls].include?(pref)
+    end
+  end,
+  'Link policy URLs should be an array' => lambda do |link|
+    link[:urls].is_a?(Array)
+  end,
+  'Link policy allow list should be a boolean' => lambda do |link|
+    [true, false].include? link[:allow_list]
+  end,
+         }
+
+action :create do
+  directory object_dir(false) do
+    action :create
+    recursive true
+  end
+
+  file object_file(false) do
+    content JSON.generate(global_config_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file(false)}]"
+  end
+
+  execute "sensuctl create -f #{object_file(false)}" do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -407,3 +407,16 @@ sensu_search 'check-config' do
   ]
   resource 'core.v2/CheckConfig'
 end
+
+sensu_global_config 'custom-web-ui' do
+  default_preferences(page_size: 50,
+                      theme: 'deuteranopia')
+  link_policy(allow_list: true,
+              urls: [
+                'https://example.com',
+                'steamapp://34234234',
+                '//google.com',
+                '//*.google.com',
+                '//bob.local',
+              ])
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -310,3 +310,11 @@ describe json('/etc/sensu/search/check-config.json') do
   its(%w(metadata namespace)) { should eq 'default' }
   its(%w(spec resource)) { should eq 'core.v2/CheckConfig' }
 end
+
+describe json('/etc/sensu/global_config/custom-web-ui.json') do
+  its(%w(type)) { should eq 'GlobalConfig' }
+  its(%w(api_version)) { should eq 'web/v1' }
+  its(%w(metadata created_by)) { should eq 'chef-client' }
+  its(%w(spec default_preferences theme)) { should eq 'deuteranopia' }
+  its(%w(spec link_policy allow_list)) { should eq true }
+end


### PR DESCRIPTION
This adds a resource for managing global Web UI config in licensed sensu
enterprise instances

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #105

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Support configuration of global Web UI settings in Sensu

#### Known Compatibility Issues

None.