### PR TITLE
Add sensu_tessen_config resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - `sensu_etcd_replicator` resource for managing cluster RBAC federation (@webframp)
 - `sensu_search` resource added (@webframp)
 - `sensu_global_config` resource to manage web ui configuration (@webframp)
+- `sensu_tessen_config` resource to manage tessen analytics preference (@webframp)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -852,6 +852,24 @@ sensu_global_config 'custom-web-ui' do
 end
 ```
 
+### sensu_tessen_config
+
+Tessen sends anonymized data about Sensu instances to Sensu Inc., including the version, cluster size, number of events processed, and number of resources created. This resource allows users to control their preference for cluster analytics collection.
+
+This does not affect licensed Sensu instances since Tessen is enabled by default and required in those cases.
+
+#### Properties
+
+* `opt_out` Set to `true` to opt out of default analytics collection
+
+### Examples
+
+``` rb
+sensu_tessen_config 'default' do
+  opt_out true
+end
+```
+
 ## License & Authors
 
 If you would like to see the detailed LICENSE click [here](./LICENSE).

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -298,6 +298,12 @@ module SensuCookbook
       config
     end
 
+    def tessen_config_from_resource
+      spec = {}
+      spec['opt_out'] = new_resource.opt_out
+      base_resource(new_resource, spec, 'core/v2')
+    end
+
     def latest_version?(version)
       version == 'latest' || version == :latest
     end

--- a/resources/tessen_config.rb
+++ b/resources/tessen_config.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: sensu-go
+# Resource:: tessen_config
+#
+# Copyright:: 2020 Sensu, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+include SensuCookbook::SensuMetadataProperties
+include SensuCookbook::SensuCommonProperties
+
+resource_name :sensu_tessen_config
+provides :sensu_tessen_config
+
+action_class do
+  include SensuCookbook::Helpers
+end
+
+property :opt_out, [true, false], required: true
+
+action :create do
+  directory object_dir(false) do
+    action :create
+    recursive true
+  end
+
+  file object_file(false) do
+    content JSON.generate(tessen_config_from_resource)
+    notifies :run, "execute[sensuctl create -f #{object_file(false)}]"
+  end
+
+  execute "sensuctl create -f #{object_file(false)}" do
+    action :nothing
+  end
+end

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -420,3 +420,7 @@ sensu_global_config 'custom-web-ui' do
                 '//bob.local',
               ])
 end
+
+sensu_tessen_config 'default' do
+  opt_out true
+end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -318,3 +318,7 @@ describe json('/etc/sensu/global_config/custom-web-ui.json') do
   its(%w(spec default_preferences theme)) { should eq 'deuteranopia' }
   its(%w(spec link_policy allow_list)) { should eq true }
 end
+
+describe json('/etc/sensu/tessen_config/default.json') do
+  its(%w(spec opt_out)) { should eq true }
+end


### PR DESCRIPTION
While we should all generally be supporting Sensu by sending anonymized
telemtry data, it's understandable that some users may not want to do
this.

This custom resource allows them to manage the opt-out settings for
tessen.

* https://docs.sensu.io/sensu-go/latest/operations/monitor-sensu/tessen/
* https://blog.sensu.io/announcing-tessen-the-sensu-call-home-service

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #105

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Cookstyle (rubocop) passes

- [X] Rspec (unit tests) passes

- [X] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Allow users to opt-out (or in!) to tessen analytics

#### Known Compatibility Issues

None