### PR TITLE
Add windows github action workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,35 @@
+---
+name: windows
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  windows_agent:
+    runs-on: windows-latest
+    services:
+      sensubackend:
+        image: sensu/sensu
+        ports:
+          - 8080:8080
+          - 8080:8081
+          - 3000:3000
+        env:
+          SENSU_BACKEND_CLUSTER_ADMIN_USERNAME: ci
+          SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD: insecure
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Install Chef
+        uses: actionshub/chef-install@master
+      - name: Kitchen Converge
+        uses: actionshub/test-kitchen@master
+        env:
+          CHEF_LICENSE: accept-no-persist
+          KITCHEN_LOCAL_YAML: kitchen.macos.yml
+        with:
+          suite: agent
+          os: windows-2019


### PR DESCRIPTION
At the moment I don't believe this will work because it depends on
services which require a `runs-on` value of a linux host.

Opening this as a draft PR just to track attempts at solving this.

----

## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #68

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Cookstyle (rubocop) passes

- [ ] Rspec (unit tests) passes

- [ ] Inspec (integration tests) passes

#### New Features

- [ ] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [ ] Added documentation for it to the `README.md`

#### Purpose

Add a GH Action for testing the windows agent in CI

#### Known Compatibility Issues

In cookbook none. With GH Actions, service containers aren't supported on windows runners.