### PR TITLE
Moved package installs for Windows to Chocolatey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 - Moved to Chocolatey to manage sensuctl and sensu-agent on Windows. (@kovukono)
 - `sensu_agent` and `sensu_ctl` for Windows now receive their version from the `version` attribute of the resource instead of `node['sensu-go']['msi_version']` and `node['sensu-go']['ctl_version']`. (@kovukono)
-- Added `migrate` resource to `sencu_ctl` to remove old Windows installation from this cookbook.
+- Added `cleanup_legacy_cookbook_install` resource to `sencu_ctl` to remove old Windows installation from this cookbook.
 
 ## [1.3.0] - 2020-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 - Introduced CI/CD testing for windows for agent and ctl (@derekgroh)
 
-### Changed
+### Breaking
 
-- Moved to Chocolatey to manage sensuctl and sensu-agent on Windows. (@kovukono)
+- Moved to Chocolatey to manage sensuctl and sensu-agent on Windows. Previously, this installed version 6.1.0 for Windows. This will now install the latest version if the `version` attribute is not set for `sensu_agent`. This may also cause issues with existing installations, as the Chocolatey package manager cannot see the existing installation. (@kovukono)
 
 ## [1.3.0] - 2020-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 - Introduced CI/CD testing for windows for agent and ctl (@derekgroh)
 
+### Changed
+
+- Moved to Chocolatey to manage sensuctl and sensu-agent on Windows. (@kovukono)
+
 ## [1.3.0] - 2020-10-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,16 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 
 - Introduced CI/CD testing for windows for agent and ctl (@derekgroh)
 
-### Breaking
+### Breaking Changes
 
-- Moved to Chocolatey to manage sensuctl and sensu-agent on Windows. Previously, this installed version 6.1.0 for Windows. This will now install the latest version if the `version` attribute is not set for `sensu_agent`. This may also cause issues with existing installations, as the Chocolatey package manager cannot see the existing installation. (@kovukono)
+- (Windows) New installation method will install the latest version of sensu-agent and sensuctl if not specified. To keep the previously installed version, specify `version '6.1.0.3465'` for `sensu_agent` and `sensu_ctl`. (@kovukono)
+- (Windows) New installation method will cause a duplicate sensuctl executable due to a difference in install location between the Chocolatey package and the previously defined extraction location for the cookbook. This can be fixed by removing the folder `c:\Program Files\Sensu\sensu-cli\bin\sensuctl`, or by using the `:migrate` action for `sensu_ctl`.
+
+### Changed
+
+- Moved to Chocolatey to manage sensuctl and sensu-agent on Windows. (@kovukono)
+- `sensu_agent` and `sensu_ctl` for Windows now receive their version from the `version` attribute of the resource instead of `node['sensu-go']['msi_version']` and `node['sensu-go']['ctl_version']`. (@kovukono)
+- Added `migrate` resource to `sencu_ctl` to remove old Windows installation from this cookbook.
 
 ## [1.3.0] - 2020-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 ### Breaking Changes
 
 - (Windows) New installation method will install the latest version of sensu-agent and sensuctl if not specified. To keep the previously installed version, specify `version '6.1.0.3465'` for `sensu_agent` and `sensu_ctl`. (@kovukono)
-- (Windows) New installation method will cause a duplicate sensuctl executable due to a difference in install location between the Chocolatey package and the previously defined extraction location for the cookbook. This can be fixed by removing the folder `c:\Program Files\Sensu\sensu-cli\bin\sensuctl`, or by using the `:migrate` action for `sensu_ctl`.
+- (Windows) New installation method will cause a duplicate sensuctl executable due to a difference in install location between the Chocolatey package and the previously defined extraction location for the cookbook. This can be fixed by removing the folder `c:\Program Files\Sensu\sensu-cli\bin\sensuctl`, or by using the `:cleanup_legacy_cookbook_install` action for `sensu_ctl`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,15 @@ sensu_ctl 'default' do
 end
 ```
 
+Migrating on Windows from version 1.3.0 or earlier of this cookbook to a later version.
+
+```rb
+sensuctl 'default' do
+  action [:migrate, :install]
+  version '6.1.0.3465'
+end
+```
+
 ### sensu_check
 
 The sensu_check resource is used to define check objects.

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Migrating on Windows from version 1.3.0 or earlier of this cookbook to a later v
 
 ```rb
 sensuctl 'default' do
-  action [:migrate, :install]
+  action [:cleanup_legacy_cookbook_install, :install]
   version '6.1.0.3465'
 end
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following platforms have been tested with Test Kitchen. It will most likely 
 ## Cookbook Dependencies
 
 * [packagecloud](https://supermarket.chef.io/cookbooks/packagecloud)
+* [chocolatey](https://supermarket.chef.io/cookbooks/chocolatey/)
 
 ## Usage
 

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -1,4 +1,1 @@
 default['sensu-go']['sensu_bindir'] = 'c:/Program Files/sensu/sensu-agent/bin'
-default['sensu-go']['windows_msi_source'] = 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/6.1.0/sensu-go-agent_6.1.0.3465_en-US.x64.msi'
-default['sensu-go']['windows_msi_checksum'] = 'EDDDBEC298837B69DCFD5A575B620CC7285A51C7F31801AE650FFD343837ACAB'
-default['sensu-go']['msi_version'] = '6.1.0'

--- a/attributes/ctl.rb
+++ b/attributes/ctl.rb
@@ -1,1 +1,0 @@
-default['sensu-go']['ctl_version'] = '6.1.0'

--- a/libraries/helpers_sensuctl.rb
+++ b/libraries/helpers_sensuctl.rb
@@ -22,7 +22,7 @@ module SensuCookbook
         if node['platform'] != 'windows'
           [sensuctl_bin, 'configure', sensuctl_configure_opts].flatten
         else
-          ['sensuctl.exe', 'configure', sensuctl_configure_opts].flatten.join(' ')
+          ["& '#{sensuctl_bin}'", 'configure', sensuctl_configure_opts].flatten.join(' ')
         end
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,3 +27,4 @@ issues_url 'https://github.com/sensu/sensu-go-chef/issues'
 source_url 'https://github.com/sensu/sensu-go-chef'
 
 depends 'packagecloud'
+depends 'chocolatey'

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -36,7 +36,6 @@ property :config, Hash, default: { "name": node['hostname'],
                                    "backend-url": ['ws://127.0.0.1:8081'],
                                  }
 action :install do
-  # Linux installation - source package
   if platform?('windows')
     include_recipe 'chocolatey'
     chocolatey_package 'sensu-agent' do
@@ -61,6 +60,7 @@ action :install do
     windows_service 'SensuAgent' do
       action [:enable, :start]
     end
+  # Linux installation - source package
   else
     packagecloud_repo new_resource.repo do
       type value_for_platform_family(

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -37,7 +37,31 @@ property :config, Hash, default: { "name": node['hostname'],
                                  }
 action :install do
   # Linux installation - source package
-  unless platform?('windows')
+  if platform?('windows')
+    include_recipe 'chocolatey'
+    chocolatey_package 'sensu-agent' do
+      action :install
+      version new_resource.version unless new_resource.version == 'latest'
+    end
+
+    # render template at c:\Programdata\Sensu\config\agent.yml for windows
+    file ::File.join('c:/ProgramData/Sensu/config/', 'agent.yml') do
+      content(YAML.dump(JSON.parse(new_resource.config.to_json)).to_s)
+      notifies :restart, 'windows_service[SensuAgent]', :delayed
+    end
+
+    # Installs SensuAgent Service
+    powershell_script 'SensuAgent Service' do
+      code '.\\sensu-agent.exe service install'
+      cwd node['sensu-go']['sensu_bindir']
+      not_if '((Get-Service SensuAgent).Name -eq "SensuAgent")'
+    end
+
+    # Enable and start SensuAgent service
+    windows_service 'SensuAgent' do
+      action [:enable, :start]
+    end
+  else
     packagecloud_repo new_resource.repo do
       type value_for_platform_family(
         %w(rhel fedora amazon) => 'rpm',
@@ -76,59 +100,29 @@ action :install do
       end
     end
   end
-
-  # Installs msi for Sensu-Go
-  if platform?('windows')
-    windows_package 'sensu-go-agent' do
-      source node['sensu-go']['windows_msi_source']
-      installer_type :custom
-      version node['sensu-go']['msi_version']
-    end
-
-    # Adds install directory to path
-    windows_path node['sensu-go']['sensu_bindir']
-
-    # render template at c:\Programdata\Sensu\config\agent.yml for windows
-    file ::File.join('c:/ProgramData/Sensu/config/', 'agent.yml') do
-      content(YAML.dump(JSON.parse(new_resource.config.to_json)).to_s)
-      notifies :restart, 'service[SensuAgent]', :delayed
-    end
-
-    # Installs SensuAgent Service
-    powershell_script 'SensuAgent Service' do
-      code '.\\sensu-agent.exe service install'
-      cwd node['sensu-go']['sensu_bindir']
-      not_if '((Get-Service SensuAgent).Name -eq "SensuAgent")'
-    end
-
-    # Enable and start SensuAgent service
-    service 'SensuAgent' do
-      action [:enable, :start]
-    end
-  end
 end
 
 action :uninstall do
-  unless platform?('windows')
+  if platform?('windows')
+    windows_service 'SensuAgent' do
+      action :stop
+    end
+    # Removes SensuAgent Service
+    powershell_script 'SensuAgent Service' do
+      code '.\\sensu-agent.exe service uninstall'
+      cwd node['sensu-go']['sensu_bindir']
+      only_if '((Get-Service SensuAgent).Name -eq "SensuAgent")'
+    end
+
+    chocolatey_package 'sensu-agent' do
+      action :remove
+    end
+  else
     service 'sensu-agent' do
       action [:disable, :stop]
     end
 
     package 'sensu-go-agent' do
-      action :remove
-    end
-  end
-
-  if platform?('windows')
-    windows_service 'SensuAgent' do
-      action [:stop, :delete]
-    end
-
-    registry_key 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\SensuAgent' do
-      action :delete_key
-    end
-
-    windows_package 'Sensu Agent' do
       action :remove
     end
   end

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -82,7 +82,7 @@ action :configure do
 end
 
 # This removes the folder we were previously putting the binary into.
-action :migrate do
+action :cleanup_legacy_cookbook_install do
   if platform?('windows')
     windows_path sensuctl_bin do
       action :remove

--- a/resources/ctl.rb
+++ b/resources/ctl.rb
@@ -81,6 +81,20 @@ action :configure do
   end
 end
 
+# This removes the folder we were previously putting the binary into.
+action :migrate do
+  if platform?('windows')
+    windows_path sensuctl_bin do
+      action :remove
+    end
+
+    directory sensuctl_bin do
+      action :delete
+      recursive true
+    end
+  end
+end
+
 action :uninstall do
   if platform?('windows')
     chocolatey_package 'sensu-cli' do

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -13,6 +13,9 @@ RSpec.shared_context 'common_stubs' do
       allow(provider).to receive_shell_out('sensuctl user list')
       allow(provider).to receive_shell_out('sensuctl version').and_return(double(run_command: nil, error!: nil, stdout: 'sensuctl version 0.0.0', stderr: '', exitstatus: 0, live_stream: '')) # Windows check if Sensuctl is installed
     end
+    stubs_for_resource('powershell_script[Install Chocolatey]') do |resource|
+      allow(resource).to receive_shell_out("powershell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Unrestricted -InputFormat None -Command \"[System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'MACHINE')\"")
+    end
     stub_command("Test-Path c:/sensutemp/sensu-go_6.1.0_windows_amd64.tar.gz").and_return(true) # rubocop:disable Style/StringLiterals
   end
 end

--- a/spec/unit/recipes/sensu_agent_spec.rb
+++ b/spec/unit/recipes/sensu_agent_spec.rb
@@ -78,15 +78,7 @@ RSpec.shared_examples 'sensu_agent_win' do |platform, version|
     end
 
     it 'installs package sensu agent' do
-      expect(chef_run).to install_windows_package('sensu-go-agent')
-    end
-
-    it 'adds a path to windows variable' do
-      expect(chef_run).to add_windows_path('c:/Program Files/sensu/sensu-agent/bin')
-    end
-
-    it 'writes the agent config file' do
-      expect(chef_run).to create_file('c:/ProgramData/Sensu/config/agent.yml')
+      expect(chef_run).to install_chocolatey_package('sensu-agent')
     end
 
     it 'runs a powershell script' do
@@ -94,8 +86,8 @@ RSpec.shared_examples 'sensu_agent_win' do |platform, version|
     end
 
     it 'enables and starts sensuagent service' do
-      expect(chef_run).to enable_service('SensuAgent')
-      expect(chef_run).to start_service('SensuAgent')
+      expect(chef_run).to enable_windows_service('SensuAgent')
+      expect(chef_run).to start_windows_service('SensuAgent')
     end
   end
 end
@@ -169,17 +161,12 @@ RSpec.shared_examples 'remove_sensu_agent_win' do |platform, version|
       expect { chef_run }.to_not raise_error
     end
 
-    it 'stops and deletes a service `SensuAgent`' do
+    it 'stops a service `SensuAgent`' do
       expect(chef_run).to stop_windows_service('SensuAgent')
-      expect(chef_run).to delete_windows_service('SensuAgent')
-    end
-
-    it 'deletes a registy key `HKLM\\SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\SensuAgent`' do
-      expect(chef_run).to delete_key_registry_key('HKLM\\SYSTEM\\CurrentControlSet\\Services\\EventLog\\Application\\SensuAgent')
     end
 
     it 'removes a package `Sensu Agent`' do
-      expect(chef_run).to remove_windows_package('Sensu Agent')
+      expect(chef_run).to remove_chocolatey_package('sensu-agent')
     end
   end
 end

--- a/spec/unit/recipes/sensu_ctl_spec.rb
+++ b/spec/unit/recipes/sensu_ctl_spec.rb
@@ -76,23 +76,8 @@ RSpec.shared_examples 'sensu_ctl_win' do |platform, version|
       expect { chef_run }.to_not raise_error
     end
 
-    it 'does nothing for an archive' do
-      expect(chef_run).to nothing_archive_file('Extract Sensuctl')
-      archive_file_resource = chef_run.archive_file('Extract Sensuctl')
-      expect(archive_file_resource).to notify('directory[c:\sensutemp]')
-    end
-
-    it 'notifies to extract the archive' do
-      ps_resource = chef_run.powershell_script('Download Sensuctl')
-      expect(ps_resource).to notify('archive_file[Extract Sensuctl]')
-    end
-
-    it 'adds `c:\Program Files\Sensu\sensu-cli\bin\sensuctl` to windows path' do
-      expect(chef_run).to add_windows_path('c:\Program Files\Sensu\sensu-cli\bin\sensuctl')
-    end
-
-    it 'deletes the temporary directory `c:\sensutemp`' do
-      expect(chef_run).to nothing_directory('c:\sensutemp')
+    it 'installs package sensu cli' do
+      expect(chef_run).to install_chocolatey_package('sensu-cli')
     end
 
     it 'configures the sensu cli' do

--- a/test/cookbooks/sensu_test/recipes/default.rb
+++ b/test/cookbooks/sensu_test/recipes/default.rb
@@ -289,7 +289,7 @@ sensu_cluster_role_binding 'cluster_admins-all_access' do
 end
 
 sensu_active_directory 'example-active-directory' do
-  ad_servers [{
+  servers [{
     'host': '127.0.0.1',
     'group_search': {
       'base_dn': 'dc=acme,dc=org',

--- a/test/integration/agent/agent_spec.rb
+++ b/test/integration/agent/agent_spec.rb
@@ -33,7 +33,7 @@ if os.linux?
 end
 
 if os.windows?
-  describe package('sensu agent') do
+  describe chocolatey_package('sensu-agent') do
     it { should be_installed }
   end
 

--- a/test/integration/ctl/ctl_spec.rb
+++ b/test/integration/ctl/ctl_spec.rb
@@ -31,8 +31,8 @@ if os.linux?
 end
 
 if os.windows?
-  describe command('cmd.exe /c "echo %PATH%"') do
-    its('stdout') { should include 'c:\Program Files\Sensu\sensu-cli\bin\sensuctl' }
+  describe os_env('PATH', 'system') do
+    its('split') { should include 'C:\Program Files\Sensu\sensu-cli\\\\bin' }
   end
 
   describe chocolatey_package('sensu-cli') do

--- a/test/integration/ctl/ctl_spec.rb
+++ b/test/integration/ctl/ctl_spec.rb
@@ -35,8 +35,8 @@ if os.windows?
     its('stdout') { should include 'c:\Program Files\Sensu\sensu-cli\bin\sensuctl' }
   end
 
-  describe file('c:\Program Files\Sensu\sensu-cli\bin\sensuctl\sensuctl.exe') do
-    it { should exist }
+  describe chocolatey_package('sensu-cli') do
+    it { should be_installed }
   end
 
   describe command('sensuctl entity list') do

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -292,10 +292,10 @@ describe json('/etc/sensu/secrets/env-secret-default.json') do
 end
 
 %w(cluster_role_binding_replicator
-  cluster_role_replicator
-  insecure_role_replicator
-  role_binding_replicator
-  role_replicator).each do |replicator|
+   cluster_role_replicator
+   insecure_role_replicator
+   role_binding_replicator
+   role_replicator).each do |replicator|
   describe json("/etc/sensu/etcd_replicator/#{replicator}.json") do
     its(%w(type)) { should eq 'EtcdReplicator' }
     its(%w(api_version)) { should eq 'federation/v1' }
@@ -306,9 +306,9 @@ end
 end
 
 %w(cluster_role_binding_replicator
-  cluster_role_replicator
-  role_binding_replicator
-  role_replicator).each do |replicator|
+   cluster_role_replicator
+   role_binding_replicator
+   role_replicator).each do |replicator|
   describe json("/etc/sensu/etcd_replicator/#{replicator}.json") do
     its(%w(spec insecure)) { should eq false }
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [x] Cookstyle (rubocop) passes

- [x] Rspec (unit tests) passes

- [x] Inspec (integration tests) passes

#### New Features

- [X] Added a [Testing Artifact](https://github.com/sensu-plugins/community/blob/master/PULL_REQUEST_PROCESS.md#7-testing-artifacts) as either an automated test or a manual artifact on the PR.

- [X] Added documentation for it to the `README.md`

#### Purpose

Move Windows to a package manager instead of tarball extraction.

#### Known Compatibility Issues

This may cause unexpected package upgrades on Windows when moving to this. However, this can be avoided by setting 6.1.0 as the version for the `sensu_agent` and `sensu_ctl` resources.